### PR TITLE
Do `--set-upstream` for untracked branches during traverse

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## New in git-machete 2.7.0
+
+- improved: during `traverse`, if there's a branch that's untracked, no longer rely on `git push` implicitly picking `origin` as the default remote;
+  instead, either choose the only existing remote if there's just one defined (even if it's not `origin`), or let the user pick the remote explicitly if there is more than one
+
 ## New in git-machete 2.6.2
 
 - improved: fork-point algorithm and upstream inference algorithm taking into account reflogs of remote counterparts of local branches

--- a/git-machete
+++ b/git-machete
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import textwrap
 
-VERSION = '2.6.2'
+VERSION = '2.7.0'
 
 
 # Core utils
@@ -47,7 +47,7 @@ def ask_if(msg):
 
 
 def pick(choices, name):
-    xs = "".join("[%i] %s\n" % (idx + 1, x) for x, idx in zip(choices, range(len(choices))))
+    xs = "".join("[%i] %s\n" % (idx + 1, x) for idx, x in enumerate(choices))
     msg = xs + "Specify " + name + " or hit <return> to skip: "
     try:
         idx = int(raw_input(msg)) - 1
@@ -789,18 +789,44 @@ def traverse():
                 elif ans in ('q', 'quit'):
                     return
             else:
-                needs_force = s == DIVERGED_FROM_REMOTE
-                force_string = " with force" if needs_force else ""
-                target_string = " to %s%s%s" % (BOLD, remote, ENDC) if remote else ""
+                if remote:
+                    needs_force = s == DIVERGED_FROM_REMOTE
+                    force_string = " with force" if needs_force else ""
 
-                print_new_line(False)
-                ans = raw_input("Push %s%s%s%s%s? [y/n/q] " % (BOLD, b, ENDC, force_string, target_string)).lower()
-                if ans in ('y', 'yes'):
-                    params = (["--force"] if needs_force else []) + ([remote] if remote else ["--set-upstream"])
-                    run_git("push", *params)
-                    flush()
-                elif ans in ('q', 'quit'):
-                    return
+                    print_new_line(False)
+                    ans = raw_input("Push %s%s%s%s to %s%s%s? [y/n/q] " % (BOLD, b, ENDC, force_string, BOLD, remote, ENDC)).lower()
+                    if ans in ('y', 'yes'):
+                        params = ["--force"] if needs_force else []
+                        run_git("push", remote, *params)
+                        flush()
+                    elif ans in ('q', 'quit'):
+                        return
+                else:
+                    print_new_line(False)
+                    if len(remotes()) == 1:
+                        remote = remotes()[0]
+                        ans = raw_input("Push untracked branch %s%s%s to %s%s%s? [y/n/q] " % (BOLD, b, ENDC, BOLD, remote, ENDC)).lower()
+                        if ans in ('y', 'yes'):
+                            run_git("push", "--set-upstream", remote, b)
+                            flush()
+                        elif ans in ('q', 'quit'):
+                            return
+                    else:
+                        # We know that there is at least 1 remote, otherwise `s` would be `NO_REMOTES` and thus `needs_remote_sync` would be false.
+                        print "Branch %s%s%s is untracked." % (BOLD, b, ENDC)
+                        print "\n".join("[%i] %s" % (idx + 1, r) for idx, r in enumerate(remotes()))
+                        msg = "Select number 1..%i to specify the destination remote repository, or 'n' to skip the push, or 'q' to quit the traverse: " % len(remotes())
+                        ans = raw_input(msg).lower()
+                        try:
+                            idx = int(ans) - 1
+                            if idx not in range(len(remotes())):
+                                raise MacheteException("Invalid index: %i" % (idx + 1))
+                            run_git("push", "--set-upstream", remotes()[idx], b)
+                            flush()
+                        except ValueError:
+                            if ans in ('q', 'quit'):
+                                return
+
     print_new_line(False)
     status()
     print

--- a/git-machete
+++ b/git-machete
@@ -495,6 +495,29 @@ def commits_between(earlier, later):
     return non_empty_lines(popen_git("log", "--format=%s", "^" + earlier, later, "--"))
 
 
+NO_REMOTES = 0
+UNTRACKED = 1
+UNTRACKED_ON = 2
+IN_SYNC_WITH_REMOTE = 3
+BEHIND_REMOTE = 4
+AHEAD_OF_REMOTE = 5
+DIVERGED_FROM_REMOTE = 6
+
+
+def get_remote_sync_status(b):
+    if not remotes():
+        return NO_REMOTES, None
+    remote = remote_for_branch(b)
+    if not remote:
+        return UNTRACKED, None
+    rb = remote_tracking_branch(b)
+    if not rb:
+        return UNTRACKED_ON, remote
+    if is_ancestor(b, rb):
+        return (IN_SYNC_WITH_REMOTE, remote) if is_ancestor(rb, b) else (BEHIND_REMOTE, remote)
+    else:
+        return (AHEAD_OF_REMOTE, remote) if is_ancestor(rb, b) else (DIVERGED_FROM_REMOTE, remote)
+
 
 # Reflog magic
 
@@ -802,60 +825,49 @@ def traverse():
                     elif ans in ('q', 'quit'):
                         return
                 else:
+                    def pick_remote():
+                        print "\n".join("[%i] %s" % (idx + 1, r) for idx, r in enumerate(rems))
+                        msg = "Select number 1..%i to specify the destination remote repository, or 'n' to skip the push, or 'q' to quit the traverse: " % len(rems)
+                        ans = raw_input(msg).lower()
+                        try:
+                            idx = int(ans) - 1
+                            if idx not in range(len(rems)):
+                                raise MacheteException("Invalid index: %i" % (idx + 1))
+                            run_git("push", "--set-upstream", rems[idx], b)
+                            flush()
+                            return True
+                        except ValueError:
+                            if ans in ('q', 'quit'):
+                                return False # do not continue traversal
+                            else:
+                                return True # just skip the current push, but continue traversal afterwards
+
                     print_new_line(False)
-                    if len(remotes()) == 1:
-                        remote = remotes()[0]
-                        ans = raw_input("Push untracked branch %s%s%s to %s%s%s? [y/n/q] " % (BOLD, b, ENDC, BOLD, remote, ENDC)).lower()
+                    rems = remotes()
+                    if "origin" in rems or len(rems) == 1:
+                        remote = "origin" if "origin" in rems else rems[0]
+                        can_pick_other_remote = "origin" in rems and len(rems) > 1
+                        other_remote_suffix = "/o[ther remote]" if can_pick_other_remote else ""
+                        ans = raw_input("Push untracked branch %s%s%s to %s%s%s? (y/n/q%s) " % (BOLD, b, ENDC, BOLD, remote, ENDC, other_remote_suffix)).lower()
                         if ans in ('y', 'yes'):
                             run_git("push", "--set-upstream", remote, b)
                             flush()
+                        elif can_pick_other_remote and ans in ('o', 'other'):
+                            if not pick_remote():
+                                return
                         elif ans in ('q', 'quit'):
                             return
                     else:
                         # We know that there is at least 1 remote, otherwise `s` would be `NO_REMOTES` and thus `needs_remote_sync` would be false.
-                        print "Branch %s%s%s is untracked." % (BOLD, b, ENDC)
-                        print "\n".join("[%i] %s" % (idx + 1, r) for idx, r in enumerate(remotes()))
-                        msg = "Select number 1..%i to specify the destination remote repository, or 'n' to skip the push, or 'q' to quit the traverse: " % len(remotes())
-                        ans = raw_input(msg).lower()
-                        try:
-                            idx = int(ans) - 1
-                            if idx not in range(len(remotes())):
-                                raise MacheteException("Invalid index: %i" % (idx + 1))
-                            run_git("push", "--set-upstream", remotes()[idx], b)
-                            flush()
-                        except ValueError:
-                            if ans in ('q', 'quit'):
-                                return
+                        print "Branch %s%s%s is untracked and there's no %sorigin%s repository." % (BOLD, b, ENDC, BOLD, ENDC)
+                        if not pick_remote():
+                            return
 
     print_new_line(False)
     status()
     print
     msg = "Reached branch %s%s%s which has no successor" if cb == managed_branches[-1] else "No successor of %s%s%s needs sync with upstream branch or remote"
     print >> sys.stderr, msg % (BOLD, cb, ENDC) + "; nothing left to update"
-
-
-NO_REMOTES = 0
-UNTRACKED = 1
-UNTRACKED_ON = 2
-IN_SYNC_WITH_REMOTE = 3
-BEHIND_REMOTE = 4
-AHEAD_OF_REMOTE = 5
-DIVERGED_FROM_REMOTE = 6
-
-
-def get_remote_sync_status(b):
-    if not remotes():
-        return NO_REMOTES, None
-    remote = remote_for_branch(b)
-    if not remote:
-        return UNTRACKED, None
-    rb = remote_tracking_branch(b)
-    if not rb:
-        return UNTRACKED_ON, remote
-    if is_ancestor(b, rb):
-        return (IN_SYNC_WITH_REMOTE, remote) if is_ancestor(rb, b) else (BEHIND_REMOTE, remote)
-    else:
-        return (AHEAD_OF_REMOTE, remote) if is_ancestor(rb, b) else (DIVERGED_FROM_REMOTE, remote)
 
 
 def status():


### PR DESCRIPTION
## Expected behavior/subcommand output

When doing a `traverse`, and answering 'yes' to pushing an untracked branch, I'd expect the traverse to continue without errors.

## Actual behavior/subcommand output

Machete stops with an error saying I need to set the upstream for the untracked branch. Which is ok-ish, but would be much better if the prompt included a proposal to set the upstream for me and push.

```
artur@y510p:~/projects/rchain$ git machete traverse 
Checking out hold_my_beer

  dev
  │ 
  └─hold_my_beer (untracked)
  │ 
  └─local_changes
  │ │ 
  │ └─staksafe_hashcode (ahead of origin)
  │   │ 
  │   └─recursion_schemes
  │ 
  └─pre_commit_hook
  │ 
  └─pretty_spec (untracked)
  │ 
  └─rho_parse

Push hold_my_beer? [y/n/q] y
fatal: The current branch hold_my_beer has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin hold_my_beer

'git push --set-upstream' returned 128
```