### PR TITLE
Make the ZSH completion file autoloadable

### DIFF
--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#compdef git-machete
 
 _git-machete() {
     local ret=1


### PR DESCRIPTION
This simple change in the ZSH completion file allows it to be automatically loaded as long as it is in the `fpath` (for instance by moving it to `/usr/share/zsh/site-functions/`), see the [ZSH doc](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files).

This should allow package managers to install the completion without user interaction.