### PR TITLE
Avoid error if no known roots are found before traversal

### DIFF
--- a/git_machete/cmd.py
+++ b/git_machete/cmd.py
@@ -1479,6 +1479,8 @@ def discover_tree():
         roots = ["master"]
     elif "develop" in local_branches():
         roots = ["develop"]
+    else:
+        raise MacheteException("Could not determine repository roots automatically. Please use `--roots=branch,names` to manually specify the roots.")
     down_branches = {}
     up_branch = {}
     indent = "\t"

--- a/git_machete/cmd.py
+++ b/git_machete/cmd.py
@@ -1480,7 +1480,7 @@ def discover_tree():
     elif "develop" in local_branches():
         roots = ["develop"]
     else:
-        raise MacheteException("Could not determine repository roots automatically. Please use `--roots=branch,names` to manually specify the roots.")
+        roots = []
     down_branches = {}
     up_branch = {}
     indent = "\t"


### PR DESCRIPTION
Quick potential fix for #103.

~~This is a very simple fix to just display a human-readable error if roots cannot be found.
If possible, better root discovery can be considered.~~

As suggested, just assigns an empty list to avoid name errors and allow the program to proceed and find the roots in later steps.