### PR TITLE
Always assume FP(b) = b if b is merged to parent, regardless of overrides

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - improved: slide-out can target branches with any number of downstream (child) branches
 - fixed: detection of no-op rebase cases in fork-point algorithm
+- fixed: if a branch is merged to its parent, `git machete status -l` now always displays an empty list of commits
 
 ## New in git-machete 3.1.1
 

--- a/git_machete/cmd.py
+++ b/git_machete/cmd.py
@@ -1771,6 +1771,13 @@ def fork_point_and_containing_branch_defs(cli_ctxt: CommandLineContext, b: str, 
     global up_branch
     u = up_branch.get(b)
 
+    if is_merged_to_upstream(cli_ctxt, b):
+        fp_sha = commit_sha_by_revision(cli_ctxt, b)
+        debug(cli_ctxt,
+              f"fork_point_and_containing_branch_defs({b})",
+              f"{b} is merged to {u}; skipping inference, using tip of {b} ({fp_sha}) as fork point")
+        return fp_sha, []
+
     if use_overrides:
         overridden_fp_sha = get_overridden_fork_point(cli_ctxt, b)
         if overridden_fp_sha:


### PR DESCRIPTION
Related to changes in #129, CC @asford