### PR TITLE
Extract a separate `--no-detect-squash-merges` option of `status` and `traverse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ even when **multiple branches** are present in the repository
 </p>
 
 🔌 See also [VirtusLab/git-machete-intellij-plugin](https://github.com/VirtusLab/git-machete-intellij-plugin#git-machete-intellij-plugin) &mdash;
-a port into a plugin for the IntelliJ Platform products.
+a port into a plugin for the IntelliJ Platform products, including PyCharm, WebStorm etc.
 
 
 ## Install

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 - improved: slide-out can target branches with any number of downstream (child) branches
 - fixed: detection of no-op rebase cases in fork-point algorithm
 - fixed: if a branch is merged to its parent, `git machete status -l` now always displays an empty list of commits
-- improved: `traverse` and `status` can detect rebase and squash merges via diff-tree, use `--no-detect-squashes` to fall back to strict merge detection
+- improved: `traverse` and `status` by default also consider squash merges when checking if a branch is merged to parent, use `--no-detect-squash-merges` to fall back to strict merge detection
 
 ## New in git-machete 3.1.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 - improved: slide-out can target branches with any number of downstream (child) branches
 - fixed: detection of no-op rebase cases in fork-point algorithm
 - fixed: if a branch is merged to its parent, `git machete status -l` now always displays an empty list of commits
-- improved: `traverse` and `status` can detect rebase and squash merges via diff-tree, use `--merge` to fallback to strict merge detection
+- improved: `traverse` and `status` can detect rebase and squash merges via diff-tree, use `--no-detect-squashes` to fall back to strict merge detection
 
 ## New in git-machete 3.1.1
 

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -21,8 +21,8 @@ _git_machete() {
     local reapply_opts="-f --fork-point="
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
-    local status_opts="--color= -L --list-commits-with-hashes -l --list-commits -M --merge"
-    local traverse_opts="-F --fetch -l --list-commits -M --merge -n --no-edit-merge --no-interactive-rebase --return-to= --start-from= -w --whole -W -y --yes"
+    local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
+    local traverse_opts="-F --fetch -l --list-commits -M --merge -n --no-detect-squash-merges --no-edit-merge --no-interactive-rebase --return-to= --start-from= -w --whole -W -y --yes"
     local update_opts="-f --fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
 
     case $cur in

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -102,7 +102,7 @@ _git-machete() {
                         '(--color)'--color='[Colorize the output; argument can be "always", "auto", or "never"]: :__git_machete_opt_color_args' \
                         '(-L --list-commits-with-hashes)'{-L,--list-commits-with-hashes}'[List the short hashes and messages of commits introduced on each branch]' \
                         '(-l --list-commits)'{-l,--list-commits}'[List the messages of commits introduced on each branch]' \
-                        '(-M --merge)'{-M,--merge}'[Strictly detect merge, rather than rebase]' \
+                        '(--no-detect-squash-merges)'--no-detect-squash-merges'[Only consider "strict" (fast-forward or 2-parent) merges, rather than rebase/squash merges, when detecting if a branch is merged into its upstream]' \
                     && ret=0
                     ;;
                 (traverse)
@@ -111,6 +111,7 @@ _git-machete() {
                         '(-l --list-commits)'{-l,--list-commits}'[List the messages of commits introduced on each branch]' \
                         '(-M --merge)'{-M,--merge}'[Update by merge rather than by rebase]' \
                         '(-n)'-n'[If updating by rebase, equivalent to --no-interactive-rebase. If updating by merge, equivalent to --no-edit-merge]' \
+                        '(--no-detect-squash-merges)'--no-detect-squash-merges'[Only consider "strict" (fast-forward or 2-parent) merges, rather than rebase/squash merges, when detecting if a branch is merged into its upstream]' \
                         '(--no-edit-merge)'--no-edit-merge'[If updating by merge, pass --no-edit flag to underlying git merge]' \
                         '(--no-interactive-rebase)'--no-interactive-rebase'[If updating by rebase, do NOT pass --interactive flag to underlying git rebase]' \
                         '(--return-to)'--return-to='[The branch to return after traversal is successfully completed; argument can be "here", "nearest-remaining", or "stay"]: :__git_machete_opt_return_to_args' \

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -445,9 +445,9 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-        # but under --merge, feature is detected as "x" (behind) develop
+        # but under --no-detect-squash-merges, feature is detected as "x" (behind) develop
         self.assert_command(
-            ["status", "-l", "--merge"],
+            ["status", "-l", "--no-detect-squash-merges"],
             """
             root
             |


### PR DESCRIPTION
Another follow-up to @asford's PR #129, based on #132