### PR TITLE
Resolve auth token from `gh` command line interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ git machete anno --sync-github-prs
 ```
 
 This will automatically annotate the branches with GitHub PR numbers. <br/>
-**Note**: for private repositories, a GitHub API token (`repo` access is required) will be taken from `GITHUB_TOKEN` env var.
+
+**Note**: for private repositories, a GitHub API token with `repo` access is required. 
+This will be resolved from the first of:
+1. The `GITHUB_TOKEN` env var.
+2. The auth token from the current [`gh`](https://cli.github.com/) configuration.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ git machete anno --sync-github-prs
 
 This will automatically annotate the branches with GitHub PR numbers. <br/>
 
-**Note**: for private repositories, a GitHub API token with `repo` access is required. 
+**Note**: for private repositories, a GitHub API token with `repo` access is required.
 This will be resolved from the first of:
 1. The `GITHUB_TOKEN` env var.
 2. The auth token from the current [`gh`](https://cli.github.com/) configuration.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.2.1
 
 - fixed: newly created branches were sometimes incorrectly recognized as merged to parent
+- improved: GitHub API token is resolved from `gh` if available
 
 ## New in git-machete 3.2.0
 

--- a/git_machete/cmd.py
+++ b/git_machete/cmd.py
@@ -2853,8 +2853,11 @@ def usage(c: str = None) -> None:
 
             If invoked with `-H` or `--sync-github-prs`, annotates the branches based on their corresponding GitHub PR numbers and authors.
             Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
+
             To allow GitHub API access for private repositories (and also to correctly identify the current user, even in case of public repositories),
-            `GITHUB_TOKEN` env var must contain a GitHub API token with `repo` scope, see `https://github.com/settings/tokens`.
+            a GitHub API token with `repo` scope is required, see `https://github.com/settings/tokens`. This will be resolved from the first of:
+            1. The `GITHUB_TOKEN` env var.
+            2. The current auth token from the `gh` GitHub CLI.
 
             In any other case, sets the annotation for the given/current branch to the given argument.
             If multiple arguments are passed to the command, they are concatenated with a single space.

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -47,6 +47,7 @@ def _token_from_gh() -> Optional[str]:
     # `gh` can store auth token for public and enterprise domains, specify
     # single domain for lookup.
     # This is *only* github.com until enterprise support is added.
+    # https://github.com/VirtusLab/git-machete/issues/137
     proc = subprocess.run(
         [gh, "auth", "status", "--hostname", GITHUB_DOMAIN, "--show-token"],
         stdout=subprocess.PIPE,
@@ -89,7 +90,7 @@ def fire_github_api_get_request(url: str, token: Optional[str]) -> Any:
     if token:
         headers['Authorization'] = 'Bearer ' + token
 
-    host = 'api' + GITHUB_DOMAIN
+    host = 'api.' + GITHUB_DOMAIN
     conn: HTTPSConnection = HTTPSConnection(host)
 
     try:

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -23,7 +23,7 @@ class GitHubPullRequest(object):
         return f"PR #{self.number} by {self.user}: {self.head} -> {self.base}"
 
 
-GITHUB_TOKEN_ENV_VAR = "GITHUB_TOKEN"
+GITHUB_TOKEN_ENV_VAR = 'GITHUB_TOKEN'
 
 # GitHub Enterprise deployments use alternate domains.
 # The logic in this module will need to be expanded to detect
@@ -64,7 +64,7 @@ def _token_from_gh() -> Optional[str]:
     # with non-zero exit code on failure
     result = proc.stderr.decode()
 
-    match = re.search("Token: (\w+)", result)
+    match = re.search(r"Token: (\w+)", result)
     if match:
         return match.groups()[0]
 
@@ -74,6 +74,7 @@ def _token_from_gh() -> Optional[str]:
 def _token_from_env() -> Optional[str]:
     return os.environ.get(GITHUB_TOKEN_ENV_VAR)
 
+
 def github_token() -> Optional[str]:
     token = _token_from_env()
 
@@ -81,6 +82,7 @@ def github_token() -> Optional[str]:
         token = _token_from_gh()
 
     return token
+
 
 def fire_github_api_get_request(url: str, token: Optional[str]) -> Any:
     headers: Dict[str, str] = {

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -104,11 +104,11 @@ def fire_github_api_get_request(url: str, token: Optional[str]) -> Any:
             first_line = fmt(f'GitHub API returned {response.status} HTTP status with error message: `{body.get("message")}`.\n')
             if token:
                 raise MacheteException(
-                    first_line + fmt(f'Make sure that the token provided in <b>{GITHUB_TOKEN_ENV_VAR}</b> env var is valid '
+                    first_line + fmt(f'Make sure that the token provided in `gh auth status` or <b>{GITHUB_TOKEN_ENV_VAR}</b> valid '
                                      f'and allows for access to `GET https://{host}{url}`.'))
             else:
                 raise MacheteException(
-                    first_line + fmt(f'This repository might be private. Provide a GitHub API token with `repo` access in <b>{GITHUB_TOKEN_ENV_VAR}</b> env var.\n'
+                    first_line + fmt(f'This repository might be private. Provide a GitHub API token with `repo` access via `gh` or <b>{GITHUB_TOKEN_ENV_VAR}</b> env var.\n'
                                      'Visit `https://github.com/settings/tokens` to generate a new one.'))
     except OSError as e:
         raise MacheteException(f'Could not connect to {host}: {e}')


### PR DESCRIPTION
Token management is a long-standing problem, as GitHub access tokens are a ...high impact... sekrat.

Storing a long-lived token in an environment variable is totally reasonable for some processes, 
but runs the risk of accidental token leak and manual token management.

Users of GitHub-oriented CLI tools may be reasonably expected to be aware of `gh`, 
which can provide a central point for token creation and management.

Optionally resolve the current token via `gh auth status` if the `gh` tool is available and configured and `GITHUB_TOKEN` is defined.