### PR TITLE
Enable passing branch to `show` command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release notes
 
-## New in git-machete 3.2.2
-- improved: `show` can accept a target `--branch` other than the current branch (contributed by @asford)
+## New in git-machete 3.3.0
+- improved: `show` can accept a target branch other than the current branch (contributed by @asford)
 
 ## New in git-machete 3.2.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## New in git-machete 3.2.2
+- improved: `show` can accept a target `--branch` other than the current branch (contributed by @asford)
+
 ## New in git-machete 3.2.1
 
 - fixed: newly created branches were sometimes incorrectly recognized as merged to parent

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -19,7 +19,6 @@ _git_machete() {
     local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
     local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
     local reapply_opts="-f --fork-point="
-    local show_opts="-b --branch="
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
     local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
@@ -44,7 +43,6 @@ _git_machete() {
                 discover) __gitcomp "$common_opts $discover_opts" ;;
                 fork-point) __gitcomp "$common_opts $fork_point_opts" ;;
                 reapply) __gitcomp "$common_opts $reapply_opts" ;;
-                show) __gitcomp "$common_opts $show_opts" ;;
                 slide-out) __gitcomp "$common_opts $slide_out_opts" ;;
                 squash) __gitcomp "$common_opts $squash_opts" ;;
                 s|status) __gitcomp "$common_opts $status_opts" ;;

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -19,6 +19,7 @@ _git_machete() {
     local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
     local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
     local reapply_opts="-f --fork-point="
+    local show_opts="-b --branch="
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
     local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
@@ -43,6 +44,7 @@ _git_machete() {
                 discover) __gitcomp "$common_opts $discover_opts" ;;
                 fork-point) __gitcomp "$common_opts $fork_point_opts" ;;
                 reapply) __gitcomp "$common_opts $reapply_opts" ;;
+                show) __gitcomp "$common_opts $show_opts" ;;
                 slide-out) __gitcomp "$common_opts $slide_out_opts" ;;
                 squash) __gitcomp "$common_opts $squash_opts" ;;
                 s|status) __gitcomp "$common_opts $status_opts" ;;

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -79,7 +79,9 @@ _git-machete() {
                     && ret=0
                     ;;
                 (show)
-                    _arguments '1:: :__git_machete_directions_show' && ret=0
+                    _arguments '1:: :__git_machete_directions_show' \
+                        '(-b --branch)'{-b,--branch=}'[Target branch for show]: :__git_machete_list_managed' \
+                    && ret=0
                     ;;
                 (slide-out)
                     _arguments \

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -80,8 +80,8 @@ _git-machete() {
                     ;;
                 (show)
                     _arguments '1:: :__git_machete_directions_show' \
-                        '(-b --branch)'{-b,--branch=}'[Target branch for show]: :__git_machete_list_managed' \
-                    && ret=0
+                      '2:: :__git_machete_list_managed' \
+                      && ret=0
                     ;;
                 (slide-out)
                     _arguments \

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -598,7 +598,7 @@ class MacheteTester(unittest.TestCase):
 
         self.assertEqual(
             self.launch_command(
-                "show", "--branch=call-ws", "up",
+                "show", "up", "call-ws",
             ).strip(),
             "develop"
         )


### PR DESCRIPTION
Add branch as optional parameter to show command, 
providing a target for the relative direction other than the current branch.

This provides support for querying the current machete structure without changing the current branch pointer.
Used while, for example, scanning machete branches for current upstream status.

Expanded completion scripts, help, tests, and README.