### PR TITLE
 Add --no-push and --no-push-untracked to traverse

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## New in git-machete 3.3.0
 - improved: `show` can accept a target branch other than the current branch (contributed by @asford)
+- added: `--no-push` and `--no-push-remote` flags in `traverse` optionally skip pushing to remote (contributed by @asford)
 
 ## New in git-machete 3.2.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release notes
 
-## New in git-machete 3.2.2
-- improved: `show` can accept a target `--branch` other than the current branch (contributed by @asford)
+## New in git-machete 3.3.0
+- improved: `show` can accept a target branch other than the current branch (contributed by @asford)
 
 ## New in git-machete 3.2.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## New in git-machete 3.2.2
+- improved: `show` can accept a target `--branch` other than the current branch (contributed by @asford)
+
 ## New in git-machete 3.2.1
 
 - fixed: newly created branches were sometimes incorrectly recognized as merged to parent

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -22,7 +22,7 @@ _git_machete() {
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
     local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
-    local traverse_opts="-F --fetch -l --list-commits -M --merge -n --no-detect-squash-merges --no-edit-merge --no-interactive-rebase --return-to= --start-from= -w --whole -W -y --yes"
+    local traverse_opts="-F --fetch -l --list-commits -M --merge -n --no-detect-squash-merges --no-edit-merge --no-interactive-rebase --no-push --push --no-push-untracked --push-untracked --return-to= --start-from= -w --whole -W -y --yes"
     local update_opts="-f --fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
 
     case $cur in

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -19,7 +19,6 @@ _git_machete() {
     local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
     local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
     local reapply_opts="-f --fork-point="
-    local show_opts="-b --branch="
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
     local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
@@ -44,7 +43,6 @@ _git_machete() {
                 discover) __gitcomp "$common_opts $discover_opts" ;;
                 fork-point) __gitcomp "$common_opts $fork_point_opts" ;;
                 reapply) __gitcomp "$common_opts $reapply_opts" ;;
-                show) __gitcomp "$common_opts $show_opts" ;;
                 slide-out) __gitcomp "$common_opts $slide_out_opts" ;;
                 squash) __gitcomp "$common_opts $squash_opts" ;;
                 s|status) __gitcomp "$common_opts $status_opts" ;;

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -19,6 +19,7 @@ _git_machete() {
     local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
     local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
     local reapply_opts="-f --fork-point="
+    local show_opts="-b --branch="
     local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
     local squash_opts="-f --fork-point="
     local status_opts="--color= -L --list-commits-with-hashes -l --list-commits --no-detect-squash-merges"
@@ -43,6 +44,7 @@ _git_machete() {
                 discover) __gitcomp "$common_opts $discover_opts" ;;
                 fork-point) __gitcomp "$common_opts $fork_point_opts" ;;
                 reapply) __gitcomp "$common_opts $reapply_opts" ;;
+                show) __gitcomp "$common_opts $show_opts" ;;
                 slide-out) __gitcomp "$common_opts $slide_out_opts" ;;
                 squash) __gitcomp "$common_opts $squash_opts" ;;
                 s|status) __gitcomp "$common_opts $status_opts" ;;

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -79,7 +79,9 @@ _git-machete() {
                     && ret=0
                     ;;
                 (show)
-                    _arguments '1:: :__git_machete_directions_show' && ret=0
+                    _arguments '1:: :__git_machete_directions_show' \
+                        '(-b --branch)'{-b,--branch=}'[Target branch for show]: :__git_machete_list_managed' \
+                    && ret=0
                     ;;
                 (slide-out)
                     _arguments \

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -116,6 +116,10 @@ _git-machete() {
                         '(--no-detect-squash-merges)'--no-detect-squash-merges'[Only consider "strict" (fast-forward or 2-parent) merges, rather than rebase/squash merges, when detecting if a branch is merged into its upstream]' \
                         '(--no-edit-merge)'--no-edit-merge'[If updating by merge, pass --no-edit flag to underlying git merge]' \
                         '(--no-interactive-rebase)'--no-interactive-rebase'[If updating by rebase, do NOT pass --interactive flag to underlying git rebase]' \
+                        '(--no-push)'--no-push'[Do not push updated branches to remote.]' \
+                        '(--no-push-untracked)'--no-push-untracked'[Do not push branches without existing remote tracking branch to remote.]' \
+                        '(--push)'--push'[Push updated branches to remote. (default)]' \
+                        '(--push-untracked)'--push-untracked'[Push branches without existing remote tracking branch to remote. (default)]' \
                         '(--return-to)'--return-to='[The branch to return after traversal is successfully completed; argument can be "here", "nearest-remaining", or "stay"]: :__git_machete_opt_return_to_args' \
                         '(--start-from)'--start-from='[The branch to  to start the traversal from; argument can be "here", "root", or "first-root"]: :__git_machete_opt_start_from_args' \
                         '(-w --whole)'{-w,--whole}'[Equivalent to -n --start-from=first-root --return-to=nearest-remaining]' \

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -80,8 +80,8 @@ _git-machete() {
                     ;;
                 (show)
                     _arguments '1:: :__git_machete_directions_show' \
-                        '(-b --branch)'{-b,--branch=}'[Target branch for show]: :__git_machete_list_managed' \
-                    && ret=0
+                      '2:: :__git_machete_list_managed' \
+                      && ret=0
                     ;;
                 (slide-out)
                     _arguments \

--- a/git_machete/cmd.py
+++ b/git_machete/cmd.py
@@ -3376,9 +3376,13 @@ long_docs: Dict[str, str] = {
           <b>--no-interactive-rebase</b>      If updating by rebase, run `git rebase` in non-interactive mode (without `-i/--interactive` flag).
                                        Not allowed if updating by merge.
 
-          <b>--no-push</b>                  Do not push branches to remote, reenable via --push.
+          <b>--no-push</b>                    Do not push branches to remote, reenable via --push.
 
-          <b>--no-push-untracked</b>        Do not push branches without existing remote tracking branch to remote, reenable via --push-untracked.
+          <b>--push</b>                       Push branches to remote, default behavior.
+
+          <b>--no-push-untracked</b>          Do not push branches without existing remote tracking branch to remote, reenable via --push-untracked.
+
+          <b>--push-untracked</b>             Push branches without existing remote tracking branch to remote, default behavior.
 
           <b>--return-to=WHERE</b>            Specifies the branch to return after traversal is successfully completed; WHERE can be `here` (the current branch at the moment when traversal starts),
                                        `nearest-remaining` (nearest remaining branch in case the `here` branch has been slid out by the traversal)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -86,6 +86,10 @@ class MacheteTester(unittest.TestCase):
         self.assertEqual(self.launch_command(*cmd), self.adapt(expected_result))
 
     def setUp(self) -> None:
+        # Status diffs can be quite large, default to ~256 lines of diff context
+        # https://docs.python.org/3/library/unittest.html#unittest.TestCase.maxDiff
+        self.maxDiff = 80 * 256
+
         self.setup = SandboxSetup()
 
         (
@@ -179,7 +183,6 @@ class MacheteTester(unittest.TestCase):
         )
 
     def test_traverse_no_push(self) -> None:
-        self.maxDiff = None
         self.setup_discover_standard_tree()
 
         self.launch_command("traverse", "-Wy", "--no-push")
@@ -214,7 +217,6 @@ class MacheteTester(unittest.TestCase):
         )
 
     def test_traverse_no_push_override(self) -> None:
-        self.maxDiff = None
         self.setup_discover_standard_tree()
 
         self.launch_command("traverse", "-Wy", "--no-push", "--push")
@@ -249,7 +251,6 @@ class MacheteTester(unittest.TestCase):
         )
 
     def test_traverse_no_push_untracked(self) -> None:
-        self.maxDiff = None
         self.setup_discover_standard_tree()
 
         self.launch_command("traverse", "-Wy", "--no-push-untracked")
@@ -502,7 +503,6 @@ class MacheteTester(unittest.TestCase):
         )
 
     def test_squash_merge(self) -> None:
-        self.maxDiff = None
         repo = (
             self.setup.new_branch("root")
             .commit("root")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -598,7 +598,7 @@ class MacheteTester(unittest.TestCase):
 
         self.assertEqual(
             self.launch_command(
-                "show", "--branch=call-ws", "up",
+                "show", "up", "call-ws",
             ).strip(),
             "develop"
         )


### PR DESCRIPTION
`traverse` is a workhorse that nearly always doing "what you want".
However, nearly always is not always...

As the rebase flow executed by `traverse` can be destructive,
it can be nice to fully review the result before pushing.

Add `--no-push` to `traverse` to allow a two-pass workflow:

1. `git machete traverse --no-push` to perform branch updates.
2. `git machete status` to review the full traverse result.
3. `git machete traverse` to push the result to origin.

Add `--no-push-untracked` to support untracked branches,
where one may not want to push to origin.

Add toggle-ish `--push` and `--push-untracked` flags to re-enable.

For example:
1. Alias `traverse` to `machete traverse --no-push`.
2. Selectively push via an interactive `traverse --push`.