### PR TITLE
Introduce github checkout-pr command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Deprecated commands are excluded.
 | expects no ongoing rebase/merge/cherry-pick/revert/am             | `advance`, `go`, `reapply`, `slide-out`, `squash`, `traverse`, `update`                                                                        |
 | has stable output format across minor versions (plumbing command) | `file`, `fork-point`<sup>[4]</sup>, `is-managed`, `list`, `show`, `version`                                                                    |
 
-[1]: `github` can only display status, accept interactive mode or modify git repository when `create-pr` subcommand is passed and the current branch is untracked or ahead of its remote.
+[1]: `github` can only display status, accept interactive mode or modify git repository when `create-pr` or `checkout-pr` subcommand is passed.
 
 [2]: `advance` can only run fast-forward merge (`git merge --ff-only`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Deprecated commands are excluded.
 | expects no ongoing rebase/merge/cherry-pick/revert/am             | `advance`, `go`, `reapply`, `slide-out`, `squash`, `traverse`, `update`                                                                        |
 | has stable output format across minor versions (plumbing command) | `file`, `fork-point`<sup>[4]</sup>, `is-managed`, `list`, `show`, `version`                                                                    |
 
-[1]: `github` can only display status, accept interactive mode or modify git repository when `create-pr` or `checkout-pr` subcommand is passed.
+[1]: `github` can only display status, accept interactive mode or modify git repository when `create-pr` or `checkout-prs` subcommand is passed.
 
 [2]: `advance` can only run fast-forward merge (`git merge --ff-only`).
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Annotate the branches with GitHub PR numbers: <br/>
 git machete github anno-prs
 ```
 
+Checks out the PR into local branch, if pull request is found on any parent branch, it will add every parent branch up to root branch as seen by git-machete: <br/>
+```shell script
+git machete github checkout-pr [PR_number]
+```
+
 Create the PR, using the upstream (parent) branch from `.git/machete` as the base: <br/>
 ```shell script
 git machete github create-pr [--draft]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ git machete github anno-prs
 
 Check out the PR into local branch, also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally: <br/>
 ```shell script
-git machete github checkout-pr <PR_number>
+git machete github checkout-prs <PR_number>
 ```
 
 Create the PR, using the upstream (parent) branch from `.git/machete` as the base: <br/>

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Annotate the branches with GitHub PR numbers: <br/>
 git machete github anno-prs
 ```
 
-Checks out the PR into local branch, if pull request is found on any parent branch, it will add every parent branch up to root branch as seen by git-machete: <br/>
+Check out the PR into local branch, also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally: <br/>
 ```shell script
 git machete github checkout-pr [PR_number]
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ git machete github anno-prs
 
 Check out the PR into local branch, also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally: <br/>
 ```shell script
-git machete github checkout-pr [PR_number]
+git machete github checkout-pr <PR_number>
 ```
 
 Create the PR, using the upstream (parent) branch from `.git/machete` as the base: <br/>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.4.0
 
-- added: `github` command with `anno-prs`, `checkout-pr`, `create-pr` and `retarget-pr` subcommands
+- added: `github` command with `anno-prs`, `checkout-prs`, `create-pr` and `retarget-pr` subcommands
 
 ## New in git-machete 3.3.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.4.0
 
-- added: `github` command with `anno-prs`, `create-pr` and `retarget-pr` subcommands
+- added: `github` command with `anno-prs`, `checkout-pr`, `create-pr` and `retarget-pr` subcommands
 
 ## New in git-machete 3.3.1
 

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -21,6 +21,7 @@ _git_machete() {
   local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
   local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
   local github_create_pr_opts="--draft"
+  local github_checkout_pr_opts="PR_number"
   local reapply_opts="-f --fork-point="
   local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
   local squash_opts="-f --fork-point="
@@ -48,6 +49,8 @@ _git_machete() {
         github)
           if [[ ${COMP_WORDS[3]} == "create-pr" ]]; then
             __gitcomp "$common_opts $github_create_pr_opts"
+          elif [[ ${COMP_WORDS[3]} == "checkout-pr" ]]; then
+            __gitcomp "$common_opts $github_checkout_pr_opts"
           else
             __gitcomp "$common_opts"
           fi ;;
@@ -94,6 +97,8 @@ _git_machete() {
                   __gitcomp "$github_subcommands"
                 elif [[ ${COMP_WORDS[3]} == "create-pr" ]]; then
                   __gitcomp "$common_opts $github_create_pr_opts"
+                elif [[ ${COMP_WORDS[3]} == "checkout-pr" ]]; then
+                  __gitcomp "$common_opts $github_checkout_pr_opts"
                 else
                   COMPREPLY=('')
                 fi ;;

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -6,7 +6,7 @@ _git_machete() {
 
   local categories="addable managed slidable slidable-after unmanaged with-overridden-fork-point"
   local directions="down first last next prev root up"
-  local github_subcommands="anno-prs checkout-pr create-pr retarget-pr"
+  local github_subcommands="anno-prs checkout-prs create-pr retarget-pr"
   local locations="current $directions"
   local opt_color_args="always auto never"
   local opt_return_to_args="here nearest-remaining stay"
@@ -94,8 +94,6 @@ _git_machete() {
                   __gitcomp "$github_subcommands"
                 elif [[ ${COMP_WORDS[3]} == "create-pr" ]]; then
                   __gitcomp "$common_opts $github_create_pr_opts"
-                elif [[ ${COMP_WORDS[3]} == "checkout-pr" ]]; then
-                  __gitcomp "$common_opts $github_checkout_pr_opts"
                 else
                   COMPREPLY=('')
                 fi ;;

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -6,7 +6,7 @@ _git_machete() {
 
   local categories="addable managed slidable slidable-after unmanaged with-overridden-fork-point"
   local directions="down first last next prev root up"
-  local github_subcommands="anno-prs create-pr retarget-pr"
+  local github_subcommands="anno-prs checkout-pr create-pr retarget-pr"
   local locations="current $directions"
   local opt_color_args="always auto never"
   local opt_return_to_args="here nearest-remaining stay"
@@ -21,7 +21,6 @@ _git_machete() {
   local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
   local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
   local github_create_pr_opts="--draft"
-  local github_checkout_pr_opts="PR_number"
   local reapply_opts="-f --fork-point="
   local slide_out_opts="-d --down-fork-point= -M --merge -n --no-edit-merge --no-interactive-rebase"
   local squash_opts="-f --fork-point="
@@ -49,8 +48,6 @@ _git_machete() {
         github)
           if [[ ${COMP_WORDS[3]} == "create-pr" ]]; then
             __gitcomp "$common_opts $github_create_pr_opts"
-          elif [[ ${COMP_WORDS[3]} == "checkout-pr" ]]; then
-            __gitcomp "$common_opts $github_checkout_pr_opts"
           else
             __gitcomp "$common_opts"
           fi ;;

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -217,7 +217,7 @@ __git_machete_github_subcommands() {
   local github_subcommands
   github_subcommands=(
     'anno-prs:annotate the branches based on their corresponding GitHub PR numbers and authors'
-    'checkout-pr:check out the given pull request locally'
+    'checkout-prs:check out the given pull request locally'
     'create-pr:create a PR for the current branch, using the upstream (parent) branch as the PR base'
     'retarget-pr:set the base of the current branch PR to upstream (parent) branch'
   )

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -64,11 +64,11 @@ _git-machete() {
         (g|go)
           _arguments '1:: :__git_machete_directions_go' && ret=0
           ;;
-        (github)
-          _arguments '1:: :__git_machete_github_subcommands' && ret=0
-          ;;
         (help)
           _arguments '1:: :__git_machete_help_topics' && ret=0
+          ;;
+        (github)
+          _arguments '1:: :__git_machete_github_subcommands' && ret=0
           ;;
         (is-managed|l|log)
           _arguments '1:: :__git_branch_names' && ret=0
@@ -217,6 +217,7 @@ __git_machete_github_subcommands() {
   local github_subcommands
   github_subcommands=(
     'anno-prs:annotate the branches based on their corresponding GitHub PR numbers and authors'
+    'checkout-pr:checks out locally given pull request'
     'create-pr:create a PR for the current branch, using the upstream (parent) branch as the PR base'
     'retarget-pr:set the base of the current branch PR to upstream (parent) branch'
   )

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -64,11 +64,11 @@ _git-machete() {
         (g|go)
           _arguments '1:: :__git_machete_directions_go' && ret=0
           ;;
-        (help)
-          _arguments '1:: :__git_machete_help_topics' && ret=0
-          ;;
         (github)
           _arguments '1:: :__git_machete_github_subcommands' && ret=0
+          ;;
+        (help)
+          _arguments '1:: :__git_machete_help_topics' && ret=0
           ;;
         (is-managed|l|log)
           _arguments '1:: :__git_branch_names' && ret=0
@@ -217,7 +217,7 @@ __git_machete_github_subcommands() {
   local github_subcommands
   github_subcommands=(
     'anno-prs:annotate the branches based on their corresponding GitHub PR numbers and authors'
-    'checkout-pr:checks out locally given pull request'
+    'checkout-pr:check out the given pull request locally'
     'create-pr:create a PR for the current branch, using the upstream (parent) branch as the PR base'
     'retarget-pr:set the base of the current branch PR to upstream (parent) branch'
   )

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -8,7 +8,7 @@ github
 
     git machete github <subcommand>
 
-where ``<subcommand>`` is one of: ``anno-prs``, ``create-pr``, ``retarget-pr``.
+where ``<subcommand>`` is one of: ``anno-prs``, ``checkout-pr``, ``create-pr``, ``retarget-pr``.
 
 Creates, checks out and manages GitHub PRs while keeping them reflected in branch definition file.
 
@@ -24,6 +24,16 @@ a GitHub API token with ``repo`` scope is required, see https://github.com/setti
   Annotates the branches based on their corresponding GitHub PR numbers and authors.
   Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
   Equivalent to ``git machete anno --sync-github-prs``.
+
+``checkout-pr``:
+
+  Check out given pull request (by number) locally under head branch name of pull request,
+  also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
+  Once pull request is checked-out locally, modify definition file according to structure found and synchronize pull requests annotations.
+
+  **Parameters:**
+
+    <PR-number>    Pull request number to checkout.
 
 ``create-pr [--draft]``:
 

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -27,9 +27,9 @@ a GitHub API token with ``repo`` scope is required, see https://github.com/setti
 
 ``checkout-pr``:
 
-  Check out given pull request (by number) locally under head branch name of pull request,
+  Check out the head branch of the given pull request (specified by number),
   also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
-  Once pull request is checked-out locally, modify definition file according to structure found and synchronize pull requests annotations.
+  Once pull request is checked out locally, add new branches to the definition file according to the PR structure and annotate them with pull request numbers.
 
   **Parameters:**
 

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -8,7 +8,7 @@ github
 
     git machete github <subcommand>
 
-where ``<subcommand>`` is one of: ``anno-prs``, ``checkout-pr``, ``create-pr``, ``retarget-pr``.
+where ``<subcommand>`` is one of: ``anno-prs``, ``checkout-prs``, ``create-pr``, ``retarget-pr``.
 
 Creates, checks out and manages GitHub PRs while keeping them reflected in branch definition file.
 
@@ -25,11 +25,11 @@ a GitHub API token with ``repo`` scope is required, see https://github.com/setti
   Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
   Equivalent to ``git machete anno --sync-github-prs``.
 
-``checkout-pr``:
+``checkout-prs``:
 
   Check out the head branch of the given pull request (specified by number),
   also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
-  Once pull request is checked out locally, add new branches to the definition file according to the PR structure and annotate them with pull request numbers.
+  Once pull request is checked out locally, annotate local branches with corresponding pull request numbers.
 
   **Parameters:**
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -423,8 +423,8 @@ def launch(orig_args: List[str]) -> None:
             elif len(list_args) > 2:
                 raise MacheteException(f"Too many arguments to `git machete list {list_args[0]}` ")
             elif (list_args[0] in (
-                 "addable", "managed", "slidable", "unmanaged", "with-overridden-fork-point") and\
-                 len(list_args) > 1):
+                    "addable", "managed", "slidable", "unmanaged", "with-overridden-fork-point") and
+                  len(list_args) > 1):
                 raise MacheteException(
                     f"`git machete list {list_args[0]}` does not expect extra arguments")
             elif list_args[0] == "slidable-after" and len(list_args) != 2:

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -365,7 +365,7 @@ def launch(orig_args: List[str]) -> None:
             if dest != current_branch:
                 git.checkout(dest)
         elif cmd == "github":
-            github_allowed_subcommands = "anno-prs|create-pr|retarget-pr|checkout-pr"
+            github_allowed_subcommands = "anno-prs|checkout-pr|create-pr|retarget-pr"
             list_args = parse_options(args) if args[0] == 'checkout-pr' \
                 else check_required_param(parse_options(args, "", ["draft"]), github_allowed_subcommands)
             if not list_args:
@@ -375,14 +375,6 @@ def launch(orig_args: List[str]) -> None:
             machete_client.read_definition_file()
             if param == "anno-prs":
                 machete_client.sync_annotations_to_github_prs()
-            elif param == "create-pr":
-                check_required_param(parse_options(args, "", ["draft"]), github_allowed_subcommands)
-                current_branch = git.get_current_branch()
-                machete_client.create_github_pr(current_branch, draft=cli_opts.opt_draft)
-            elif param == "retarget-pr":
-                current_branch = git.get_current_branch()
-                machete_client.expect_in_managed_branches(current_branch)
-                machete_client.retarget_github_pr(current_branch)
             elif param == "checkout-pr":
                 if len(list_args) == 1:
                     raise MacheteException(
@@ -392,6 +384,14 @@ def launch(orig_args: List[str]) -> None:
                 except ValueError:
                     raise MacheteException("PR number is not integer value!")
                 machete_client.checkout_github_pr(pr_no)
+            elif param == "create-pr":
+                check_required_param(parse_options(args, "", ["draft"]), github_allowed_subcommands)
+                current_branch = git.get_current_branch()
+                machete_client.create_github_pr(current_branch, draft=cli_opts.opt_draft)
+            elif param == "retarget-pr":
+                current_branch = git.get_current_branch()
+                machete_client.expect_in_managed_branches(current_branch)
+                machete_client.retarget_github_pr(current_branch)
             else:
                 raise MacheteException(
                     f"`github` requires a subcommand: one of `{github_allowed_subcommands}`")

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -365,8 +365,8 @@ def launch(orig_args: List[str]) -> None:
             if dest != current_branch:
                 git.checkout(dest)
         elif cmd == "github":
-            github_allowed_subcommands = "anno-prs|checkout-pr|create-pr|retarget-pr"
-            list_args = parse_options(args) if args[0] == 'checkout-pr' \
+            github_allowed_subcommands = "anno-prs|checkout-prs|create-pr|retarget-pr"
+            list_args = parse_options(args) if args[0] == 'checkout-prs' \
                 else check_required_param(parse_options(args, "", ["draft"]), github_allowed_subcommands)
             if not list_args:
                 raise MacheteException(f"`git machete github` expects argument(s): {github_allowed_subcommands}")
@@ -375,15 +375,15 @@ def launch(orig_args: List[str]) -> None:
             machete_client.read_definition_file()
             if param == "anno-prs":
                 machete_client.sync_annotations_to_github_prs()
-            elif param == "checkout-pr":
+            elif param == "checkout-prs":
                 if len(list_args) == 1:
                     raise MacheteException(
-                        "Argument to `git machete github checkout-pr` cannot be empty; expected PR number.")
+                        "Argument to `git machete github checkout-prs` cannot be empty; expected PR number.")
                 try:
                     pr_no: int = int(list_args[1])
                 except ValueError:
                     raise MacheteException("PR number is not integer value!")
-                machete_client.checkout_github_pr(pr_no)
+                machete_client.checkout_github_prs(pr_no)
             elif param == "create-pr":
                 check_required_param(parse_options(args, "", ["draft"]), github_allowed_subcommands)
                 current_branch = git.get_current_branch()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1767,7 +1767,7 @@ class MacheteClient:
         except MacheteException as e:
             print(e)
             return
-
+        self.flush_caches()
         base: Optional[str] = self.up_branch.get(head)
         if not base:
             raise MacheteException(

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1688,7 +1688,7 @@ class MacheteClient:
         self.sync_annotations_to_github_prs()
 
         self.__git.checkout(pr.head)
-        print(fmt(f"Pull request #{pr.number} checked out at local branch {pr.head}"))
+        print(fmt(f"Pull request `#{pr.number}` checked out at local branch `{pr.head}`"))
 
     def get_path(self, last_branch: str) -> List[str]:
         def get_parent_branch_from_pr(branch: str) -> Optional[str]:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1673,6 +1673,7 @@ class MacheteClient:
 
         self.__git.fetch_remote(remote)
 
+        self.__cli_opts.opt_yes = True
         path: List[str] = self.get_path(pr.head)
         reversed_path: List[str] = path[::-1]  # need to add from root do down
         for index, branch in enumerate(reversed_path):
@@ -1684,7 +1685,7 @@ class MacheteClient:
                     continue
                 self.__cli_opts.opt_onto = reversed_path[index - 1]
                 self.add(branch)
-
+        self.__cli_opts.opt_yes = False
         self.sync_annotations_to_github_prs()
 
         self.__git.checkout(pr.head)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1767,7 +1767,6 @@ class MacheteClient:
         except MacheteException as e:
             print(e)
             return
-        self.flush_caches()
         base: Optional[str] = self.up_branch.get(head)
         if not base:
             raise MacheteException(

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1675,6 +1675,8 @@ class MacheteClient:
 
         print(f"Fetching {remote}...")
         self.__git.fetch_remote(remote)
+        if self.__git.remotes():
+            self.flush_caches()
 
         self.__cli_opts.opt_yes = True  # TODO (#161): pass only needed options to methods
         path: List[str] = self.__get_path_from_pr_chain(pr.head, all_prs)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -287,6 +287,7 @@ class MacheteClient:
                 self.__down_branches[onto] = [branch]
             print(fmt(f"Added branch `{branch}` onto `{onto}`"))
 
+        self.managed_branches += [branch]
         self.save_definition_file()
 
     def annotate(self, branch: str, words: List[str]) -> None:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1767,6 +1767,7 @@ class MacheteClient:
         except MacheteException as e:
             print(e)
             return
+        self.flush_caches()
         base: Optional[str] = self.up_branch.get(head)
         if not base:
             raise MacheteException(

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -15,7 +15,7 @@ from git_machete.constants import (
 from git_machete.exceptions import MacheteException, StopTraversal
 from git_machete.git_operations import GitContext
 from git_machete.github import (
-    GitHubPullRequest, find_pr_by_number, derive_pull_requests,
+    GitHubPullRequest, derive_pull_requests,
     derive_pull_request_by_head, set_base_of_pull_request, get_parsed_github_remote_url, is_github_remote_url,
     create_pull_request, derive_current_user_login, set_milestone_of_pull_request,
     add_assignees_to_pull_request, add_reviewers_to_pull_request)
@@ -1667,10 +1667,10 @@ class MacheteClient:
         debug('checkout_github_pr()', f'organization is {org}, repository is {repo}')
 
         all_prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)
-        pr: GitHubPullRequest = find_pr_by_number(pr_no, all_prs)
+        pr = utils.find_or_none(lambda pr: pr.number == pr_no, all_prs)
 
         if not pr:
-            raise MacheteException(f"PR #{pr_no} is not found in repository {org}/{repo}")
+            raise MacheteException(f"PR #{pr_no} is not found in repository `{org}/{repo}`")
         debug('checkout_github_pr()', f'found {pr}')
 
         print(f"Fetching {remote}...")
@@ -1704,7 +1704,7 @@ class MacheteClient:
         path: List[str] = [current_pr.head]
         while current_pr:
             path.append(current_pr.base)
-            current_pr = next(filter(lambda x: x.head == current_pr.base, all_prs), None)
+            current_pr = utils.find_or_none(lambda x: x.head == current_pr.base, all_prs)
         return path
 
     def retarget_github_pr(self, head: str) -> None:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1746,9 +1746,7 @@ class MacheteClient:
         if not org_and_repo_for_github_remote:
             raise MacheteException(
                 fmt('Remotes are defined for this repository, but none of them '
-                    'corresponds to GitHub (see `git remote -v` for details)\n'
-                    f'Actual remotes from git:\n {self.__git.popen_git("remote", "-v")}\n'
-                    f'Actual remotes from git-machete: {self.__git.remotes()}'))
+                    'corresponds to GitHub (see `git remote -v` for details)\n'))
 
         if len(org_and_repo_for_github_remote) == 1:
             return list(org_and_repo_for_github_remote.items())[0]

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1746,7 +1746,9 @@ class MacheteClient:
         if not org_and_repo_for_github_remote:
             raise MacheteException(
                 fmt('Remotes are defined for this repository, but none of them '
-                    'corresponds to GitHub (see `git remote -v` for details)'))
+                    'corresponds to GitHub (see `git remote -v` for details)\n'
+                    f'Actual remotes from git:\n {self.__git.popen_git("remote", "-v")}\n'
+                    f'Actual remotes from git-machete: {self.__git.remotes()}'))
 
         if len(org_and_repo_for_github_remote) == 1:
             return list(org_and_repo_for_github_remote.items())[0]

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -314,11 +314,11 @@ long_docs: Dict[str, str] = {
           Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
           Equivalent to `git machete anno --sync-github-prs`.
 
-        <b>`checkout-pr` [PR_number]`:</b>
+        <b>`checkout-pr <PR-number>`:</b>
 
-          Checks out given pull request (by number) locally under <PR_number> branch. Note this branch is read only, so there is no possibility to push changes there.
-          If pull request if found on any parent branch, `checkout-pr` will check out locally every parent branch up to root branch as seen by git-machete,
-          modify definition file according to structure found and synchronize PR annotations.
+          Check out given pull request (by number) locally under head branch name of pull request, 
+          also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
+          Once pull request is checked-out locally, modify definition file according to structure found and synchronize pull requests annotations.
 
         <b>`create-pr [--draft]`:</b>
 

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -316,7 +316,7 @@ long_docs: Dict[str, str] = {
 
         <b>`checkout-pr <PR-number>`:</b>
 
-          Check out given pull request (by number) locally under head branch name of pull request, 
+          Check out given pull request (by number) locally under head branch name of pull request,
           also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
           Once pull request is checked-out locally, modify definition file according to structure found and synchronize pull requests annotations.
 

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -316,9 +316,12 @@ long_docs: Dict[str, str] = {
 
         <b>`checkout-pr <PR-number>`:</b>
 
-          Check out given pull request (by number) locally under head branch name of pull request,
+          Check out the head branch of the given pull request (specified by number),
           also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
-          Once pull request is checked-out locally, modify definition file according to structure found and synchronize pull requests annotations.
+          Once pull request is checked out locally, add new branches to the definition file according to the PR structure and annotate them with pull request numbers.
+
+          <b>Parameters:</b>
+            <b><PR-number></b>    Pull request number to checkout.
 
         <b>`create-pr [--draft]`:</b>
 

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -298,7 +298,7 @@ long_docs: Dict[str, str] = {
     """,
     "github": """
         <b>Usage: git machete github <subcommand></b>
-        where <subcommand> is one of: `anno-prs`, `create-pr`, `retarget-pr`.
+        where <subcommand> is one of: `anno-prs`, `checkout-prs`, `create-pr`, `retarget-pr`.
 
         Creates, checks out and manages GitHub PRs while keeping them reflected in branch definition file.
 
@@ -314,11 +314,11 @@ long_docs: Dict[str, str] = {
           Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
           Equivalent to `git machete anno --sync-github-prs`.
 
-        <b>`checkout-pr <PR-number>`:</b>
+        <b>`checkout-prs <PR-number>`:</b>
 
           Check out the head branch of the given pull request (specified by number),
           also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
-          Once pull request is checked out locally, add new branches to the definition file according to the PR structure and annotate them with pull request numbers.
+          Once pull request is checked out locally, annotate local branches with corresponding pull request numbers.
 
           <b>Parameters:</b>
             <b><PR-number></b>    Pull request number to checkout.

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -314,6 +314,12 @@ long_docs: Dict[str, str] = {
           Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
           Equivalent to `git machete anno --sync-github-prs`.
 
+        <b>`checkout-pr` [PR_number]`:</b>
+
+          Checks out given pull request (by number) locally under <PR_number> branch. Note this branch is read only, so there is no possibility to push changes there.
+          If pull request if found on any parent branch, `checkout-pr` will check out locally every parent branch up to root branch as seen by git-machete,
+          modify definition file according to structure found and synchronize PR annotations.
+
         <b>`create-pr [--draft]`:</b>
 
           Creates a PR for the current branch, using the upstream (parent) branch as the PR base.

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -171,9 +171,6 @@ class GitContext:
     def set_upstream_to(self, remote_branch: str) -> None:
         self.run_git("branch", "--set-upstream-to", remote_branch)
 
-    def fetch_pull_request(self, remote: str, pr_no: int) -> None:
-        self.run_git("fetch", remote, f"refs/pull/{pr_no}/head:PR_{pr_no}")
-
     def reset_keep(self, to_revision: str) -> None:
         try:
             self.run_git("reset", "--keep", to_revision)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -413,6 +413,7 @@ class GitContext:
         self.__reflogs_cached = None
         self.__remaining_log_shas_cached = {}
         self.__remote_branches_cached = None
+        self.__remotes_cached = None
 
     def get_revision_repr(self, revision: str) -> str:
         short_sha = self.get_short_commit_sha_by_revision(revision)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -705,18 +705,3 @@ class GitContext:
                 if to_branch not in result:
                     result[to_branch] = int(match.group(1))
         return result
-
-    def get_stripped_remote_branches(self, remote: str) -> List[str]:
-        def strip_remote(branch: str, remote: str) -> str:
-            index = branch.rfind(remote)
-            return branch[index + len(remote) + 1:]
-        branches = self.get_remote_branches()
-        return [strip_remote(b, remote) for b in branches if 'HEAD' not in b]
-
-    def get_commit_timestamp(self, commit_hash: str) -> str:
-        return self.popen_git('show', '-s', '--format=%ct', commit_hash).rstrip()
-
-    def get_first_reflog_entry_timestamp(self, remote: str, branch: str) -> str:
-        output: List[str] = self.popen_git('reflog', '--format=%ct', "/".join([remote, branch])).split('\n')
-        output.remove('')
-        return output[-1].strip()  # take only last value

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -171,6 +171,9 @@ class GitContext:
     def set_upstream_to(self, remote_branch: str) -> None:
         self.run_git("branch", "--set-upstream-to", remote_branch)
 
+    def fetch_pull_request(self, remote: str, pr_no: int) -> None:
+        self.run_git("fetch", remote, f"refs/pull/{pr_no}/head:PR_{pr_no}")
+
     def reset_keep(self, to_revision: str) -> None:
         try:
             self.run_git("reset", "--keep", to_revision)
@@ -705,3 +708,18 @@ class GitContext:
                 if to_branch not in result:
                     result[to_branch] = int(match.group(1))
         return result
+
+    def get_stripped_remote_branches(self, remote: str) -> List[str]:
+        def strip_remote(branch: str, remote: str) -> str:
+            index = branch.rfind(remote)
+            return branch[index + len(remote) + 1:]
+        branches = self.get_remote_branches()
+        return [strip_remote(b, remote) for b in branches if 'HEAD' not in b]
+
+    def get_commit_timestamp(self, commit_hash: str) -> str:
+        return self.popen_git('show', '-s', '--format=%ct', commit_hash).rstrip()
+
+    def get_first_reflog_entry_timestamp(self, remote: str, branch: str) -> str:
+        output: List[str] = self.popen_git('reflog', '--format=%ct', "/".join([remote, branch])).split('\n')
+        output.remove('')
+        return output[-1].strip()  # take only last value

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -143,9 +143,16 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
         raise MacheteException(f'Could not connect to {host}: {e}')
 
 
-def __check_pr_already_created(pull: GitHubPullRequest, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
+def check_pr_already_created(pull: GitHubPullRequest, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
     for pr in pull_requests:
         if pull.base == pr.base and pull.head == pr.head:
+            return pr
+    return None
+
+
+def check_pr_already_created_by_number(no: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
+    for pr in pull_requests:
+        if no == pr.number:
             return pr
     return None
 
@@ -161,7 +168,7 @@ def create_pull_request(org: str, repo: str, head: str, base: str, title: str, d
     }
     prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)
     to_load: GitHubPullRequest = GitHubPullRequest(1, 'user', base, head, '')
-    pr_found: Optional[GitHubPullRequest] = __check_pr_already_created(to_load, prs)
+    pr_found: Optional[GitHubPullRequest] = check_pr_already_created(to_load, prs)
     if not pr_found:
         pr = __fire_github_api_request('POST', f'/repos/{org}/{repo}/pulls', token, request_body)
         return __parse_pr_json(pr)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -143,14 +143,14 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
         raise MacheteException(f'Could not connect to {host}: {e}')
 
 
-def check_pr_already_created(pull: GitHubPullRequest, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
+def find_pr_by_base_and_head(base: str, head: str, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
     for pr in pull_requests:
-        if pull.base == pr.base and pull.head == pr.head:
+        if base == pr.base and head == pr.head:
             return pr
     return None
 
 
-def check_pr_already_created_by_number(no: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
+def find_pr_by_number(no: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
     for pr in pull_requests:
         if no == pr.number:
             return pr
@@ -167,8 +167,7 @@ def create_pull_request(org: str, repo: str, head: str, base: str, title: str, d
         'draft': draft
     }
     prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)
-    to_load: GitHubPullRequest = GitHubPullRequest(1, 'user', base, head, '')
-    pr_found: Optional[GitHubPullRequest] = check_pr_already_created(to_load, prs)
+    pr_found: Optional[GitHubPullRequest] = find_pr_by_base_and_head(base, head, prs)
     if not pr_found:
         pr = __fire_github_api_request('POST', f'/repos/{org}/{repo}/pulls', token, request_body)
         return __parse_pr_json(pr)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -150,9 +150,9 @@ def find_pr_by_base_and_head(base: str, head: str, pull_requests: List[GitHubPul
     return None
 
 
-def find_pr_by_number(no: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
+def find_pr_by_number(number: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
     for pr in pull_requests:
-        if no == pr.number:
+        if number == pr.number:
             return pr
     return None
 

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Any, Tuple
 import urllib.request
 from urllib.error import HTTPError
 
-from git_machete.utils import debug, fmt
+from git_machete.utils import debug, fmt, find_or_none
 from git_machete.exceptions import MacheteException, UnprocessableEntityHTTPError
 
 
@@ -143,20 +143,6 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
         raise MacheteException(f'Could not connect to {host}: {e}')
 
 
-def find_pr_by_base_and_head(base: str, head: str, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
-    for pr in pull_requests:
-        if base == pr.base and head == pr.head:
-            return pr
-    return None
-
-
-def find_pr_by_number(number: int, pull_requests: List[GitHubPullRequest]) -> Optional[GitHubPullRequest]:
-    for pr in pull_requests:
-        if number == pr.number:
-            return pr
-    return None
-
-
 def create_pull_request(org: str, repo: str, head: str, base: str, title: str, description: str, draft: bool) -> GitHubPullRequest:
     token: Optional[str] = __get_github_token()
     request_body: Dict[str, Any] = {
@@ -167,7 +153,7 @@ def create_pull_request(org: str, repo: str, head: str, base: str, title: str, d
         'draft': draft
     }
     prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)
-    pr_found: Optional[GitHubPullRequest] = find_pr_by_base_and_head(base, head, prs)
+    pr_found: Optional[GitHubPullRequest] = find_or_none(lambda pr: pr.base == base and pr.head == head, prs)
     if not pr_found:
         pr = __fire_github_api_request('POST', f'/repos/{org}/{repo}/pulls', token, request_body)
         return __parse_pr_json(pr)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -172,7 +172,7 @@ class MockGithubAPIRequest:
         return self.make_response_object(HTTPStatus.CREATED, issue)
 
     @staticmethod
-    def get_index_or_None(entity: Dict[str, Any], base: List[Dict[str, Any]]) -> Optional[int]:
+    def get_index_or_none(entity: Dict[str, Any], base: List[Dict[str, Any]]) -> Optional[int]:
         try:
             return base.index(entity)
         except ValueError:
@@ -193,15 +193,6 @@ class MockGithubAPIRequest:
     def get_next_free_number(entities: List[Dict[str, Any]]) -> str:
         numbers = [int(item['number']) for item in entities]
         return str(max(numbers) + 1)
-
-    @staticmethod
-    def set_initial_values() -> None:
-        GitAPIState.pulls = [
-            {'head': {'ref': 'bugfix/remove'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'},
-             'number': '15', 'html_url': 'www.github.com'}]
-        GitAPIState.user = {'login': 'github_user', 'type': 'User', 'company': 'VirtusLab'}
-        GitAPIState.issues = []
-        GitAPIState.remote_branches = []
 
 
 class MockContextManager:
@@ -1576,6 +1567,7 @@ class MacheteTester(unittest.TestCase):
                 "specified by the option '-f' from the current branch."
         )
 
+
     git_api_state_for_test_retarget_pr = MockGithubAPIState(
         [{'head': {'ref': 'feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'root'}, 'number': '15',
           'html_url': 'www.github.com'}])
@@ -1583,7 +1575,6 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.Request', git_api_state_for_test_retarget_pr.new_request())
     @mock.patch('urllib.request.urlopen', MockContextManager)
     def test_retarget_pr(self) -> None:
-        GitAPIState.set_initial_values()
         branchs_first_commit_msg = "First commit on branch."
         branchs_second_commit_msg = "Second commit on branch."
         (
@@ -1614,7 +1605,6 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
     def test_anno_prs(self) -> None:
-        GitAPIState.set_initial_values()
         (
             self.repo_sandbox.new_branch("root")
                 .commit("root")
@@ -1655,6 +1645,7 @@ class MacheteTester(unittest.TestCase):
                 .delete_branch("root")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
+
         self.launch_command("discover", "-y")
         self.launch_command('github', 'anno-prs')
         self.assert_command(
@@ -1685,7 +1676,6 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
-        GitAPIState.set_initial_values()
         (
             self.repo_sandbox.new_branch("root")
                 .commit("initial commit")
@@ -1729,7 +1719,6 @@ class MacheteTester(unittest.TestCase):
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
                 .check_out("call-ws")
         )
-
         self.launch_command("discover")
         self.launch_command("github", "create-pr")
         # ahead of origin state, push is advised and accepted

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -188,7 +188,7 @@ class MockGithubAPIRequest:
 
     @staticmethod
     def find_number(url: str, entity: str) -> Optional[str]:
-        m = re.search(f'{entity}\/(\d+)', url)
+        m = re.search(f'{entity}/(\\d+)', url)
         if m:
             return m.group(1)
         return None
@@ -2022,7 +2022,23 @@ class MacheteTester(unittest.TestCase):
         self.repo_sandbox.execute(f'git clone {self.repo_sandbox.remote_path}')
         os.chdir(os.path.join(local_path, os.listdir()[0]))
         self.rewrite_definition_file("master")
-        self.assert_command(['github', 'checkout-pr', '2'], "")
+        expected_msg = ("Fetching origin...\n"
+                        "A local branch `chore/sync_to_docs` does not exist, but a remote branch `origin/chore/sync_to_docs` exists.\n"
+                        "Checking out `chore/sync_to_docs` locally...\n"
+                        "Added branch `chore/sync_to_docs` as a new root\n"
+                        "A local branch `improve/refactor` does not exist, but a remote branch `origin/improve/refactor` exists.\n"
+                        "Checking out `improve/refactor` locally...\n"
+                        "Added branch `improve/refactor` onto `chore/sync_to_docs`\n"
+                        "A local branch `comments/add_docstrings` does not exist, but a remote branch `origin/comments/add_docstrings` exists.\n"
+                        "Checking out `comments/add_docstrings` locally...\nAdded branch `comments/add_docstrings` onto `improve/refactor`\n"
+                        "Annotating comments/add_docstrings as `PR #2 (github_user)`\nAnnotating improve/refactor as `PR #1 (github_user)`\n"
+                        "Pull request `#2` checked out at local branch `comments/add_docstrings`\n")
+        self.assert_command(
+            ['github', 'checkout-pr', '2'],
+            expected_msg,
+            strip_indentation=False
+        )
+
         self.assert_command(
             ["status"],
             """

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -137,8 +137,9 @@ class MockGithubAPIRequest:
         return self.fill_pull_request_data(json.loads(self.json_data), pull)
 
     def fill_pull_request_data(self, data: Dict[str, Any], pull: Dict[str, Any]) -> "MockGithubAPIResponse":
-        index = self.get_index_or_None(pull, self.github_api_state.issues)
+        index = self.get_index_or_none(pull, self.github_api_state.issues)
         for key in data.keys():
+
             if key in ('base', 'head'):
                 pull[key] = {'ref': ""}
                 pull[key]['ref'] = json.loads(self.json_data)[key]
@@ -162,7 +163,7 @@ class MockGithubAPIRequest:
         return self.fill_issue_data(json.loads(self.json_data), issue)
 
     def fill_issue_data(self, data: Dict[str, Any], issue: Dict[str, Any]) -> "MockGithubAPIResponse":
-        index = self.get_index_or_None(issue, self.github_api_state.issues)
+        index = self.get_index_or_none(issue, self.github_api_state.issues)
         for key in data.keys():
             issue[key] = data[key]
         if index:
@@ -177,6 +178,7 @@ class MockGithubAPIRequest:
             return base.index(entity)
         except ValueError:
             return None
+
 
     @staticmethod
     def make_response_object(status_code: int, response_data: Union[List[Dict[str, Any]], Dict[str, Any]]) -> "MockGithubAPIResponse":
@@ -1567,7 +1569,6 @@ class MacheteTester(unittest.TestCase):
                 "specified by the option '-f' from the current branch."
         )
 
-
     git_api_state_for_test_retarget_pr = MockGithubAPIState(
         [{'head': {'ref': 'feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'root'}, 'number': '15',
           'html_url': 'www.github.com'}])
@@ -1600,7 +1601,6 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'allow-ownership-link'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '7', 'html_url': 'www.github.com'},
         {'head': {'ref': 'call-ws'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '31', 'html_url': 'www.github.com'}
     ])
-
 
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
@@ -1645,7 +1645,6 @@ class MacheteTester(unittest.TestCase):
                 .delete_branch("root")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
-
         self.launch_command("discover", "-y")
         self.launch_command('github', 'anno-prs')
         self.assert_command(
@@ -1668,7 +1667,6 @@ class MacheteTester(unittest.TestCase):
               x-drop-constraint (untracked)
             """,
         )
-
 
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
@@ -1719,6 +1717,7 @@ class MacheteTester(unittest.TestCase):
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
                 .check_out("call-ws")
         )
+
         self.launch_command("discover")
         self.launch_command("github", "create-pr")
         # ahead of origin state, push is advised and accepted

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1603,7 +1603,6 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
     def test_anno_prs(self) -> None:
-
         (
             self.repo_sandbox.new_branch("root")
                 .commit("root")
@@ -1667,13 +1666,13 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
-
         (
             self.repo_sandbox.new_branch("root")
                 .commit("initial commit")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1673,6 +1673,7 @@ class MacheteTester(unittest.TestCase):
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
+    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
@@ -1717,7 +1718,6 @@ class MacheteTester(unittest.TestCase):
                 .new_branch('chore/fields')
                 .commit("remove outdated fields")
                 .check_out("call-ws")
-                .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
 
         self.launch_command("discover")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1672,7 +1672,6 @@ class MacheteTester(unittest.TestCase):
 
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
-    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_create_pr` to avoid situation where there is no remotes pointing to Github.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1592,6 +1592,7 @@ class MacheteTester(unittest.TestCase):
                 .push()
                 .check_out('feature')
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
+                .sleep(1)
         )
 
         self.launch_command("discover", "-y")
@@ -1646,6 +1647,7 @@ class MacheteTester(unittest.TestCase):
                 .reset_to("ignore-trailing@{1}")
                 .delete_branch("root")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
+                .sleep(1)
         )
         self.launch_command("discover", "-y")
         self.launch_command('github', 'anno-prs')
@@ -1719,6 +1721,7 @@ class MacheteTester(unittest.TestCase):
                 .commit("remove outdated fields")
                 .check_out("call-ws")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
+                .sleep(1)
         )
 
         self.launch_command("discover")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -182,7 +182,6 @@ class MockGithubAPIRequest:
         except ValueError:
             return None
 
-
     @staticmethod
     def make_response_object(status_code: int, response_data: Union[List[Dict[str, Any]], Dict[str, Any]]) -> "MockGithubAPIResponse":
         return MockGithubAPIResponse(status_code, response_data)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -266,10 +266,6 @@ class GitRepositorySandbox:
         self.execute(f'git branch -d "{branch}"')
         return self
 
-    def add_remote(self, remote: str, url: str) -> "GitRepositorySandbox":
-        self.execute(f'git remote add {remote} {url}')
-        return self
-
 
 class MacheteTester(unittest.TestCase):
     @staticmethod
@@ -1592,12 +1588,12 @@ class MacheteTester(unittest.TestCase):
                 .commit('introduce feature')
                 .push()
                 .check_out('feature')
-                .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
 
         self.launch_command("discover", "-y")
         self.assert_command(['github', 'retarget-pr'], 'The base branch of PR #15 has been switched to `branch-1`\n', strip_indentation=False)
         self.assert_command(['github', 'retarget-pr'], 'The base branch of PR #15 is already `branch-1`\n', strip_indentation=False)
+
 
     git_api_state_for_test_anno_prs = MockGithubAPIState([
         {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'},
@@ -1646,7 +1642,6 @@ class MacheteTester(unittest.TestCase):
                 .push()
                 .reset_to("ignore-trailing@{1}")
                 .delete_branch("root")
-                .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
         self.launch_command("discover", "-y")
         self.launch_command('github', 'anno-prs')
@@ -1717,7 +1712,6 @@ class MacheteTester(unittest.TestCase):
                 .delete_branch("root")
                 .new_branch('chore/fields')
                 .commit("remove outdated fields")
-                .add_remote('new_origin', 'https://github.com/user/repo.git')
                 .check_out("call-ws")
         )
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1574,6 +1574,7 @@ class MacheteTester(unittest.TestCase):
 
     @mock.patch('urllib.request.Request', git_api_state_for_test_retarget_pr.new_request())
     @mock.patch('urllib.request.urlopen', MockContextManager)
+    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     def test_retarget_pr(self) -> None:
         branchs_first_commit_msg = "First commit on branch."
         branchs_second_commit_msg = "Second commit on branch."
@@ -1594,7 +1595,6 @@ class MacheteTester(unittest.TestCase):
         self.assert_command(['github', 'retarget-pr'], 'The base branch of PR #15 has been switched to `branch-1`\n', strip_indentation=False)
         self.assert_command(['github', 'retarget-pr'], 'The base branch of PR #15 is already `branch-1`\n', strip_indentation=False)
 
-
     git_api_state_for_test_anno_prs = MockGithubAPIState([
         {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'},
         {'head': {'ref': 'allow-ownership-link'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '7', 'html_url': 'www.github.com'},
@@ -1602,6 +1602,7 @@ class MacheteTester(unittest.TestCase):
     ])
 
     @mock.patch('urllib.request.urlopen', MockContextManager)
+    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
     def test_anno_prs(self) -> None:
         (
@@ -1669,6 +1670,7 @@ class MacheteTester(unittest.TestCase):
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
+    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
@@ -1806,12 +1808,22 @@ class MacheteTester(unittest.TestCase):
             self.assertEqual(e.exception.parameter, expected_error_message,
                              'Verify that expected error message has appeared when given pull request to create is already created.')
 
+    git_api_state_for_test_checkout_pr = MockGithubAPIState([
+        {'head': {'ref': 'chore/redundant_checks'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'restrict_access'}, 'number': '18', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'restrict_access'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'allow-ownership-link'}, 'number': '17', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'allow-ownership-link'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/feature'}, 'number': '12', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'bugfix/feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'enchance/feature'}, 'number': '6', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'enchance/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '19', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'testing/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/add_user'}, 'number': '22', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'chore/comments'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'testing/add_user'}, 'number': '24', 'html_url': 'www.github.com'},
+        {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}
+    ])
+
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
-    @mock.patch('urllib.request.urlopen', ContextManager)
-    @mock.patch('urllib.request.Request', GitAPIState)
+    @mock.patch('urllib.request.urlopen', MockContextManager)
+    @mock.patch('urllib.request.Request', git_api_state_for_test_checkout_pr.new_request())
     def test_checkout_pr(self) -> None:
-        GitAPIState.set_initial_values()
         (
             self.repo_sandbox.new_branch("root")
             .commit("initial commit")
@@ -1862,16 +1874,6 @@ class MacheteTester(unittest.TestCase):
             .push()
             .check_out('master')
         )
-        GitAPIState.pulls = [
-            {'head': {'ref': 'chore/redundant_checks'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'restrict_access'}, 'number': '18', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'restrict_access'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'allow-ownership-link'}, 'number': '17', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'allow-ownership-link'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/feature'}, 'number': '12', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'bugfix/feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'enchance/feature'}, 'number': '6', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'enchance/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '19', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'testing/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/add_user'}, 'number': '22', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'chore/comments'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'testing/add_user'}, 'number': '24', 'html_url': 'www.github.com'},
-            {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}
-        ]
         for branch in ('chore/redundant_checks', 'restrict_access', 'allow-ownership-link', 'bugfix/feature', 'enchance/add_user', 'testing/add_user', 'chore/comments', 'bugfix/add_user'):
             self.repo_sandbox.execute(f"git branch -D {branch}")
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1799,6 +1799,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
         # check against attempt to create already existing pull request
+
         machete_client = MacheteClient(cli_opts, git)
         expected_error_message = "Pull request for branch hotfix/add-trigger is already created under link www.github.com!\nPR details: PR #6 by github_user: hotfix/add-trigger -> master"
         machete_client.read_definition_file()

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -194,6 +194,15 @@ class MockGithubAPIRequest:
         numbers = [int(item['number']) for item in entities]
         return str(max(numbers) + 1)
 
+    @staticmethod
+    def set_initial_values() -> None:
+        GitAPIState.pulls = [
+            {'head': {'ref': 'bugfix/remove'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'},
+             'number': '15', 'html_url': 'www.github.com'}]
+        GitAPIState.user = {'login': 'github_user', 'type': 'User', 'company': 'VirtusLab'}
+        GitAPIState.issues = []
+        GitAPIState.remote_branches = []
+
 
 class MockContextManager:
     def __init__(self, obj: MockGithubAPIRequest) -> None:
@@ -1574,6 +1583,7 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.Request', git_api_state_for_test_retarget_pr.new_request())
     @mock.patch('urllib.request.urlopen', MockContextManager)
     def test_retarget_pr(self) -> None:
+        GitAPIState.set_initial_values()
         branchs_first_commit_msg = "First commit on branch."
         branchs_second_commit_msg = "Second commit on branch."
         (
@@ -1604,6 +1614,7 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
     def test_anno_prs(self) -> None:
+        GitAPIState.set_initial_values()
         (
             self.repo_sandbox.new_branch("root")
                 .commit("root")
@@ -1674,6 +1685,7 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
+        GitAPIState.set_initial_values()
         (
             self.repo_sandbox.new_branch("root")
                 .commit("initial commit")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -127,7 +127,7 @@ class MockGithubAPIRequest:
             return self.make_response_object(HTTPStatus.NOT_FOUND, [])
 
     def update_pull_request(self) -> "MockGithubAPIResponse":
-        pull_no: str = self.find_number(self.parsed_url.path)
+        pull_no: str = self.find_number(self.parsed_url.path, 'pulls')
         if not pull_no:
             return self.create_pull_request()
         pull: Dict[str, Any] = self.github_api_state.get_pull(pull_no)
@@ -155,7 +155,7 @@ class MockGithubAPIRequest:
         return self.make_response_object(HTTPStatus.CREATED, pull)
 
     def update_issue(self) -> "MockGithubAPIResponse":
-        issue_no: str = self.find_number(self.parsed_url.path)
+        issue_no: str = self.find_number(self.parsed_url.path, 'issues')
         if not issue_no:
             return self.create_issue()
         issue: Dict[str, Any] = self.github_api_state.get_issue(issue_no)
@@ -187,10 +187,10 @@ class MockGithubAPIRequest:
         return MockGithubAPIResponse(status_code, response_data)
 
     @staticmethod
-    def find_number(url: str) -> Optional[str]:
-        m = re.search(r'\d+', url)
+    def find_number(url: str, entity: str) -> Optional[str]:
+        m = re.search(f'{entity}\/(\d+)', url)
         if m:
-            return m.group()
+            return m.group(1)
         return None
 
     @staticmethod

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -2017,10 +2017,15 @@ class MacheteTester(unittest.TestCase):
         )
         for branch in ('develop', 'chore/sync_to_docs', 'improve/refactor', 'comments/add_docstrings'):
             self.repo_sandbox.execute(f"git branch -D {branch}")
+
         local_path = os.popen("mktemp -d").read().strip()
         os.chdir(local_path)
         self.repo_sandbox.execute(f'git clone {self.repo_sandbox.remote_path}')
         os.chdir(os.path.join(local_path, os.listdir()[0]))
+
+        for branch in ('develop', 'chore/sync_to_docs', 'improve/refactor', 'comments/add_docstrings'):
+            self.repo_sandbox.execute(f"git branch -D -r origin/{branch}")
+
         self.rewrite_definition_file("master")
         expected_msg = ("Fetching origin...\n"
                         "A local branch `chore/sync_to_docs` does not exist, but a remote branch `origin/chore/sync_to_docs` exists.\n"

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1674,7 +1674,6 @@ class MacheteTester(unittest.TestCase):
 
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_create_pr` to avoid situation where there is no remotes pointing to Github.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
-    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
     def test_github_create_pr(self) -> None:
@@ -1719,6 +1718,7 @@ class MacheteTester(unittest.TestCase):
                 .new_branch('chore/fields')
                 .commit("remove outdated fields")
                 .check_out("call-ws")
+                .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
 
         self.launch_command("discover")
@@ -1812,7 +1812,7 @@ class MacheteTester(unittest.TestCase):
             self.assertEqual(e.exception.parameter, expected_error_message,
                              'Verify that expected error message has appeared when given pull request to create is already created.')
 
-    git_api_state_for_test_checkout_pr = MockGithubAPIState([
+    git_api_state_for_test_checkout_prs = MockGithubAPIState([
         {'head': {'ref': 'chore/redundant_checks'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'restrict_access'}, 'number': '18', 'html_url': 'www.github.com'},
         {'head': {'ref': 'restrict_access'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'allow-ownership-link'}, 'number': '17', 'html_url': 'www.github.com'},
         {'head': {'ref': 'allow-ownership-link'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/feature'}, 'number': '12', 'html_url': 'www.github.com'},
@@ -1827,7 +1827,7 @@ class MacheteTester(unittest.TestCase):
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
-    @mock.patch('urllib.request.Request', git_api_state_for_test_checkout_pr.new_request())
+    @mock.patch('urllib.request.Request', git_api_state_for_test_checkout_prs.new_request())
     def test_checkout_prs(self) -> None:
         (
             self.repo_sandbox.new_branch("root")
@@ -1989,17 +1989,17 @@ class MacheteTester(unittest.TestCase):
             self.assertEqual(e.exception.parameter, expected_error_message,
                              'Verify that expected error message has appeared when given pull request to checkout does not exists.')
 
-    git_api_state_for_test_checkout_pr_fresh_repo = MockGithubAPIState([
+    git_api_state_for_test_checkout_prs_fresh_repo = MockGithubAPIState([
         {'head': {'ref': 'comments/add_docstrings'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'improve/refactor'}, 'number': '2', 'html_url': 'www.github.com'},
         {'head': {'ref': 'restrict_access'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'allow-ownership-link'}, 'number': '17', 'html_url': 'www.github.com'},
         {'head': {'ref': 'improve/refactor'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'chore/sync_to_docs'}, 'number': '1', 'html_url': 'www.github.com'},
     ])
 
-    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
+    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs_freshly_cloned` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)
-    @mock.patch('urllib.request.Request', git_api_state_for_test_checkout_pr_fresh_repo.new_request())
+    @mock.patch('urllib.request.Request', git_api_state_for_test_checkout_prs_fresh_repo.new_request())
     def test_checkout_prs_freshly_cloned(self) -> None:
         (
             self.repo_sandbox.new_branch("root")

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1600,6 +1600,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'call-ws'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '31', 'html_url': 'www.github.com'}
     ])
 
+
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
     def test_anno_prs(self) -> None:
@@ -1799,7 +1800,6 @@ class MacheteTester(unittest.TestCase):
             """,
         )
         # check against attempt to create already existing pull request
-
         machete_client = MacheteClient(cli_opts, git)
         expected_error_message = "Pull request for branch hotfix/add-trigger is already created under link www.github.com!\nPR details: PR #6 by github_user: hotfix/add-trigger -> master"
         machete_client.read_definition_file()

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1672,6 +1672,7 @@ class MacheteTester(unittest.TestCase):
 
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}])
 
+    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_create_pr` to avoid situation where there is no remotes pointing to Github.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)
@@ -1822,6 +1823,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com'}
     ])
 
+    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
@@ -1979,7 +1981,7 @@ class MacheteTester(unittest.TestCase):
         repo: str
         org: str
         (org, repo) = get_parsed_github_remote_url(self.repo_sandbox.remote_path)
-        expected_error_message = f"PR #100 is not found in repository {org}/{repo}"
+        expected_error_message = f"PR #100 is not found in repository `{org}/{repo}`"
         machete_client.read_definition_file()
         with self.assertRaises(MacheteException) as e:
             machete_client.checkout_github_prs(100)
@@ -1993,6 +1995,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'improve/refactor'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'chore/sync_to_docs'}, 'number': '1', 'html_url': 'www.github.com'},
     ])
 
+    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('urllib.request.urlopen', MockContextManager)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1592,7 +1592,6 @@ class MacheteTester(unittest.TestCase):
                 .push()
                 .check_out('feature')
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
-                .sleep(1)
         )
 
         self.launch_command("discover", "-y")
@@ -1647,7 +1646,6 @@ class MacheteTester(unittest.TestCase):
                 .reset_to("ignore-trailing@{1}")
                 .delete_branch("root")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
-                .sleep(1)
         )
         self.launch_command("discover", "-y")
         self.launch_command('github', 'anno-prs')
@@ -1721,7 +1719,6 @@ class MacheteTester(unittest.TestCase):
                 .commit("remove outdated fields")
                 .check_out("call-ws")
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
-                .sleep(1)
         )
 
         self.launch_command("discover")

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -28,6 +28,10 @@ def flat_map(func: Callable[[T], List[T]], iterable: Iterable[T]) -> List[T]:
     return sum(map(func, iterable), [])
 
 
+def find_or_none(func: Callable[[T], bool], iterable: Iterable[T]) -> T:
+    return next(filter(func, iterable), None)
+
+
 def map_truthy_only(func: Callable[[T], Optional[T]], iterable: Iterable[T]) -> List[T]:
     return list(filter(None, map(func, iterable)))
 


### PR DESCRIPTION
Known bug until now:
when `checkout-pr` detects opened PR on parent branches, it will try to add the chain of branches into definition file and also checkout them locally. then user is asked if he wants to add those branches one by one, and if he answers no in the middle the adding next branch will cause error because `onto` branch does not exists for git-machete 