### PR TITLE
get remote git url from config

### DIFF
--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -161,7 +161,7 @@ class GitContext:
         return self.__remotes_cached
 
     def get_url_of_remote(self, remote: str) -> str:
-        return self.popen_git("remote", "get-url", "--", remote).strip()
+        return self.popen_git("config", "--get", f"remote.{remote}.url").strip()
 
     def fetch_remote(self, remote: str) -> None:
         if remote not in self.__fetch_done_for:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -161,7 +161,7 @@ class GitContext:
         return self.__remotes_cached
 
     def get_url_of_remote(self, remote: str) -> str:
-        return self.popen_git("config", "--get", f"remote.{remote}.url").strip()
+        return self.popen_git("config", "--get", f"remote.{remote}.url").strip()  # 'git remote get-url' method has only been added in git v2.5.1
 
     def fetch_remote(self, remote: str) -> None:
         if remote not in self.__fetch_done_for:


### PR DESCRIPTION
Due to git 1.8 which does not support `get-url` function.