### PR TITLE
Separate mypy checks into own tox env

### DIFF
--- a/ci/tox/build-context/entrypoint.sh
+++ b/ci/tox/build-context/entrypoint.sh
@@ -8,9 +8,9 @@
 set -e -u -x
 
 if [[ $CHECK_COVERAGE = true ]]; then
-  TOX_ENV_LIST="pep8,coverage"
+  TOX_ENV_LIST="pep8,mypy-py${PYTHON_VERSION/./},coverage"
 else
-  TOX_ENV_LIST="pep8,py${PYTHON_VERSION/./}"
+  TOX_ENV_LIST="pep8,mypy-py${PYTHON_VERSION/./},py${PYTHON_VERSION/./}"
 fi
 
 if [[ $BUILD_DOCS = true ]]; then

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36,py37,py38,py39,coverage,docs
+envlist = pep8,py36,py37,py38,py39,coverage,docs,mypy
 minversion = 2.3.2
 skipsdist = True
 
@@ -13,9 +13,7 @@ install_command =
 deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
-whitelist_externals = mypy
 commands =
-  mypy --config-file mypy.ini git_machete
   stestr run {posargs}
 
 [testenv:pep8]
@@ -50,3 +48,11 @@ deps =
   sphinx-rtd-theme==0.5.2
 commands =
   sphinx-build -b html docs/source docs/html
+
+[testenv:mypy]
+whitelist_externals = mypy
+commands =
+  mypy --config-file mypy.ini --python-version 3.6 git_machete
+  mypy --config-file mypy.ini --python-version 3.7 git_machete
+  mypy --config-file mypy.ini --python-version 3.8 git_machete
+  mypy --config-file mypy.ini --python-version 3.9 git_machete

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36,py37,py38,py39,coverage,docs,mypy
+envlist = pep8,mypy-py{36,37,38,39},py{36,37,38,39},coverage,docs
 minversion = 2.3.2
 skipsdist = True
 
@@ -50,9 +50,10 @@ commands =
   sphinx-build -b html docs/source docs/html
 
 [testenv:mypy]
+whitelist_externals = tox
+commands = tox -e "mypy-py{36,37,38,39}"
+
+[testenv:mypy-py{36,37,38,39}]
 whitelist_externals = mypy
 commands =
-  mypy --config-file mypy.ini --python-version 3.6 git_machete
-  mypy --config-file mypy.ini --python-version 3.7 git_machete
-  mypy --config-file mypy.ini --python-version 3.8 git_machete
-  mypy --config-file mypy.ini --python-version 3.9 git_machete
+  mypy --config-file mypy.ini git_machete


### PR DESCRIPTION
Fixes #196 

Moved mypy check into own tox env. Allows mypy checks to be run with ```tox -e mypy```.