### PR TITLE
Allow to checkout closed pull requests

### DIFF
--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1688,7 +1688,7 @@ class MacheteClient:
             raise MacheteException(f"PR #{pr_no} is not found in repository `{org}/{repo}`")
 
         if pr.state == 'closed':
-            warn(f'Pull request #{str(pr_no)} is already closed.')
+            warn(f'Pull request #{pr_no} is already closed.')
         debug('checkout_github_pr()', f'found {pr}')
 
         all_prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -231,7 +231,7 @@ def get_parsed_github_remote_url(url: str) -> Optional[Tuple[str, str]]:
     return None
 
 
-def get_pull_request_by_number(number: str, org: str, repo: str) -> Optional[GitHubPullRequest]:
+def get_pull_request_by_number_or_none(number: str, org: str, repo: str) -> Optional[GitHubPullRequest]:
     token: Optional[str] = __get_github_token()
     try:
         pr_json: Dict[str, Any] = __fire_github_api_request('GET', f'/repos/{org}/{repo}/pulls/{number}', token)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -234,7 +234,7 @@ def get_parsed_github_remote_url(url: str) -> Optional[Tuple[str, str]]:
 def get_pull_request_by_number(number: str, org: str, repo: str) -> Optional[GitHubPullRequest]:
     token: Optional[str] = __get_github_token()
     try:
-        pr_json: Any = __fire_github_api_request('GET', f'/repos/{org}/{repo}/pulls/{number}', token)
+        pr_json: Dict[str, Any] = __fire_github_api_request('GET', f'/repos/{org}/{repo}/pulls/{number}', token)
         return __parse_pr_json(pr_json)
     except MacheteException:
         return None

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -231,7 +231,7 @@ def get_parsed_github_remote_url(url: str) -> Optional[Tuple[str, str]]:
     return None
 
 
-def get_pull_request_by_number_or_none(number: str, org: str, repo: str) -> Optional[GitHubPullRequest]:
+def get_pull_request_by_number_or_none(number: int, org: str, repo: str) -> Optional[GitHubPullRequest]:
     token: Optional[str] = __get_github_token()
     try:
         pr_json: Dict[str, Any] = __fire_github_api_request('GET', f'/repos/{org}/{repo}/pulls/{number}', token)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -1863,7 +1863,8 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'enhance/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '19', 'html_url': 'www.github.com', 'state': 'open'},
         {'head': {'ref': 'testing/add_user'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'bugfix/add_user'}, 'number': '22', 'html_url': 'www.github.com', 'state': 'open'},
         {'head': {'ref': 'chore/comments'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'testing/add_user'}, 'number': '24', 'html_url': 'www.github.com', 'state': 'open'},
-        {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com', 'state': 'open'}
+        {'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com', 'state': 'open'},
+        {'head': {'ref': 'bugfix/remove-n-option'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '5', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
@@ -2032,11 +2033,21 @@ class MacheteTester(unittest.TestCase):
             self.assertEqual(e.exception.parameter, expected_error_message,
                              'Verify that expected error message has appeared when given pull request to checkout does not exists.')
 
+        # Check against closed pull request with head branch deleted from remote
+        machete_client = MacheteClient(cli_opts, git)
+        machete_client.read_definition_file()
+        expected_error_message = "Could not checkout PR #5 because it's head branch `bugfix/remove-n-option` is already deleted from `origin`."
+        with self.assertRaises(MacheteException) as e:
+            machete_client.checkout_github_prs(5)
+        if e:
+            self.assertEqual(e.exception.parameter, expected_error_message,
+                             'Verify that expected error message has appeared when given pull request to checkout have already deleted branch from remote.')
+
     git_api_state_for_test_checkout_prs_fresh_repo = MockGithubAPIState([
         {'head': {'ref': 'comments/add_docstrings'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'improve/refactor'}, 'number': '2', 'html_url': 'www.github.com', 'state': 'open'},
         {'head': {'ref': 'restrict_access'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'allow-ownership-link'}, 'number': '17', 'html_url': 'www.github.com', 'state': 'open'},
         {'head': {'ref': 'improve/refactor'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'chore/sync_to_docs'}, 'number': '1', 'html_url': 'www.github.com', 'state': 'open'},
-        {'head': {'ref': 'sphinx_export'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'comments/add_docstrings'}, 'number': '23', 'html_url': 'www.github.com', 'state': 'closed'},
+        {'head': {'ref': 'sphinx_export'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'comments/add_docstrings'}, 'number': '23', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs_freshly_cloned` due to `git fetch` executed by `checkout-prs` subcommand.
@@ -2113,8 +2124,8 @@ class MacheteTester(unittest.TestCase):
         )
 
         # Check against closed pull request
-        expected_msg = ("Warn: Pull request #23 is already closed.\n"
-                        "Fetching origin...\n"
+        expected_msg = ("Fetching origin...\n"
+                        "Warn: Pull request #23 is already closed.\n"
                         "A local branch `sphinx_export` does not exist, but a remote branch `origin/sphinx_export` exists.\n"
                         "Checking out `sphinx_export` locally...\n"
                         "Added branch `sphinx_export` onto `comments/add_docstrings`\n"

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -49,10 +49,7 @@ class MockGithubAPIState:
     def __init__(self, pulls: List[Dict[str, Any]], issues: List[Dict[str, Any]] = None) -> None:
         self.pulls: List[Dict[str, Any]] = pulls
         self.user: Dict[str, str] = {'login': 'other_user', 'type': 'User', 'company': 'VirtusLab'}  # login must be different from the one used in pull requests, otherwise pull request author will not be annotated
-        if issues:
-            self.issues: List[Dict[str, Any]] = issues
-        else:
-            self.issues = []
+        self.issues: List[Dict[str, Any]] = issues or []
 
     def new_request(self) -> "MockGithubAPIRequest":
         return MockGithubAPIRequest(self)
@@ -2036,7 +2033,7 @@ class MacheteTester(unittest.TestCase):
         # Check against closed pull request with head branch deleted from remote
         machete_client = MacheteClient(cli_opts, git)
         machete_client.read_definition_file()
-        expected_error_message = "Could not checkout PR #5 because it's head branch `bugfix/remove-n-option` is already deleted from `origin`."
+        expected_error_message = "Could not check out PR #5 because its head branch `bugfix/remove-n-option` is already deleted from `origin`."
         with self.assertRaises(MacheteException) as e:
             machete_client.checkout_github_prs(5)
         if e:


### PR DESCRIPTION
Closes #227 

Unfortunately Github API does not provide `merged` state, there is only `open` or `closed`.