### PR TITLE
Issue #234: Fix how some command's options appear on readthedocs.

### DIFF
--- a/docs/source/cli_help/add.rst
+++ b/docs/source/cli_help/add.rst
@@ -23,9 +23,8 @@ Note: all the effects of ``add`` (except git branch creation) can as well be ach
 
 **Options:**
 
-  -o, --onto=<target-upstream-branch>    Specifies the target parent branch to add the given branch onto. Cannot be specified together with ``-R/--as-root``.
+-o, --onto=<target-upstream-branch>    Specifies the target parent branch to add the given branch onto. Cannot be specified together with ``-R/--as-root``.
 
-  -R, --as-root                          Add the given branch as a new root (and not onto any other branch). Cannot be specified together with ``-o/--onto``.
+-R, --as-root                          Add the given branch as a new root (and not onto any other branch). Cannot be specified together with ``-o/--onto``.
 
-  -y, --yes                              Don't ask for confirmation whether to create the branch or whether to add onto the inferred upstream.
-
+-y, --yes                              Don't ask for confirmation whether to create the branch or whether to add onto the inferred upstream.

--- a/docs/source/cli_help/advance.rst
+++ b/docs/source/cli_help/advance.rst
@@ -71,5 +71,4 @@ Note that the current branch after the operation is still ``develop``, just poin
 
 **Options:**
 
-  -y, --yes         Don't ask for confirmation whether to fast-forward the current branch or whether to slide-out the downstream. Fails if the current branch has more than one :green:`green-edge` downstream branch.
-
+-y, --yes         Don't ask for confirmation whether to fast-forward the current branch or whether to slide-out the downstream. Fails if the current branch has more than one :green:`green-edge` downstream branch.

--- a/docs/source/cli_help/anno.rst
+++ b/docs/source/cli_help/anno.rst
@@ -36,7 +36,6 @@ Note: all the effects of ``anno`` can be always achieved by manually editing the
 
 **Options:**
 
-  -b, --branch=<branch>     Branch to set the annotation for.
+-b, --branch=<branch>     Branch to set the annotation for.
 
-  -H, --sync-github-prs     Annotate with GitHub PR numbers and authors where applicable.
-
+-H, --sync-github-prs     Annotate with GitHub PR numbers and authors where applicable.

--- a/docs/source/cli_help/delete-unmanaged.rst
+++ b/docs/source/cli_help/delete-unmanaged.rst
@@ -17,4 +17,4 @@ See :ref:`fork-point` for more details.
 
 **Options:**
 
-  -y, --yes          Don't ask for confirmation.
+-y, --yes          Don't ask for confirmation.

--- a/docs/source/cli_help/diff.rst
+++ b/docs/source/cli_help/diff.rst
@@ -15,4 +15,4 @@ Note: the branch in question does not need to occur in the definition file.
 
 **Options:**
 
-  -s, --stat    Makes ``git machete diff`` pass ``--stat`` option to ``git diff``, so that only summary (diffstat) is printed.
+-s, --stat    Makes ``git machete diff`` pass ``--stat`` option to ``git diff``, so that only summary (diffstat) is printed.

--- a/docs/source/cli_help/discover.rst
+++ b/docs/source/cli_help/discover.rst
@@ -14,11 +14,10 @@ If the reply was ``e[dit]``, additionally an editor is opened (as in :ref:`git m
 
 **Options:**
 
-  -C, --checked-out-since=<date>   Only consider branches checked out at least once since the given date. <date> can be e.g. ``2 weeks ago`` or ``2020-06-01``, as in ``git log --since=<date>``. If not present, the date is selected automatically so that around 10 branches are included.
+-C, --checked-out-since=<date>   Only consider branches checked out at least once since the given date. <date> can be e.g. ``2 weeks ago`` or ``2020-06-01``, as in ``git log --since=<date>``. If not present, the date is selected automatically so that around 10 branches are included.
 
-  -l, --list-commits               When printing the discovered tree, additionally lists the messages of commits introduced on each branch (as for ``git machete status``).
+-l, --list-commits               When printing the discovered tree, additionally lists the messages of commits introduced on each branch (as for ``git machete status``).
 
-  -r, --roots=<branch1,...>       Comma-separated list of branches that should be considered roots of trees of branch dependencies. If not present, ``master`` is assumed to be a root. Note that in the process of discovery, certain other branches can also be additionally deemed to be roots as well.
+-r, --roots=<branch1,...>        Comma-separated list of branches that should be considered roots of trees of branch dependencies. If not present, ``master`` is assumed to be a root. Note that in the process of discovery, certain other branches can also be additionally deemed to be roots as well.
 
-  -y, --yes                        Don't ask for confirmation before saving the newly-discovered tree.
-                                   Mostly useful in scripts; not recommended for manual use.
+-y, --yes                        Don't ask for confirmation before saving the newly-discovered tree. Mostly useful in scripts; not recommended for manual use.

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -33,7 +33,8 @@ a GitHub API token with ``repo`` scope is required, see https://github.com/setti
 
   **Parameters:**
 
-    <PR-number>    Pull request number to checkout.
+    **<PR-number>**
+      Pull request number to checkout.
 
 ``create-pr [--draft]``:
 
@@ -46,7 +47,8 @@ a GitHub API token with ``repo`` scope is required, see https://github.com/setti
 
   **Options:**
 
-    --draft    Creates the new PR as a draft.
+    --draft
+      Creates the new PR as a draft.
 
 ``retarget-pr``:
 

--- a/docs/source/cli_help/reapply.rst
+++ b/docs/source/cli_help/reapply.rst
@@ -19,4 +19,4 @@ but there is also dedicated ``squash`` command that achieves the same goal witho
 
 **Options:**
 
-  -f, --fork-point=<fork-point-commit>    Specifies the alternative fork point commit after which the rebased part of history is meant to start.
+-f, --fork-point=<fork-point-commit>    Specifies the alternative fork point commit after which the rebased part of history is meant to start.

--- a/docs/source/cli_help/slide-out.rst
+++ b/docs/source/cli_help/slide-out.rst
@@ -46,17 +46,12 @@ Note: This command doesn't delete any branches from git, just removes them from 
 
 **Options:**
 
-  -d, --down-fork-point=<down-fork-point-commit>    If updating by rebase, specifies the alternative fork point for downstream branches for the operation.
-                                                    ``git machete fork-point`` overrides for downstream branches are recommended over use of this option.
-                                                    See also doc for ``--fork-point`` option in ``git machete help reapply`` and ``git machete help update``.
-                                                    Not allowed if updating by merge.
+-d, --down-fork-point=<down-fork-point-commit>    If updating by rebase, specifies the alternative fork point for downstream branches for the operation. ``git machete fork-point`` overrides for downstream branches are recommended over use of this option. See also doc for ``--fork-point`` option in ``git machete help reapply`` and ``git machete help update``. Not allowed if updating by merge.
 
-  -M, --merge                                       Update the downstream branch by merge rather than by rebase.
+-M, --merge                                       Update the downstream branch by merge rather than by rebase.
 
-  -n                                                If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
+-n                                                If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
 
-  --no-edit-merge                                   If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit`` flag to underlying ``git merge``).
-                                                    Not allowed if updating by rebase.
+--no-edit-merge                                   If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit`` flag to underlying ``git merge``). Not allowed if updating by rebase.
 
-  --no-interactive-rebase                           If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag).
-                                                    Not allowed if updating by merge.
+--no-interactive-rebase                           If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag). Not allowed if updating by merge.

--- a/docs/source/cli_help/squash.rst
+++ b/docs/source/cli_help/squash.rst
@@ -19,4 +19,4 @@ Tip: ``squash`` does NOT run ``git rebase`` under the hood. For more complex sce
 
 **Options:**
 
-  -f, --fork-point=<fork-point-commit>   Specifies the alternative fork point commit after which the squashed part of history is meant to start.
+-f, --fork-point=<fork-point-commit>   Specifies the alternative fork point commit after which the squashed part of history is meant to start.

--- a/docs/source/cli_help/status.rst
+++ b/docs/source/cli_help/status.rst
@@ -72,11 +72,10 @@ With ``--color=always``, git machete always emits colors and with ``--color=auto
 
 **Options:**
 
-  --color=WHEN                      Colorize the output; WHEN can be ``always``, ``auto`` (default; i.e. only if stdout is a terminal), or ``never``.
+--color=WHEN                      Colorize the output; WHEN can be ``always``, ``auto`` (default; i.e. only if stdout is a terminal), or ``never``.
 
-  -l, --list-commits                Additionally list the commits introduced on each branch.
+-l, --list-commits                Additionally list the commits introduced on each branch.
 
-  -L, --list-commits-with-hashes    Additionally list the short hashes and messages of commits introduced on each branch.
+-L, --list-commits-with-hashes    Additionally list the short hashes and messages of commits introduced on each branch.
 
-  --no-detect-squash-merges         Only consider `strict` (fast-forward or 2-parent) merges, rather than rebase/squash merges,
-                                    when detecting if a branch is merged into its upstream (parent).
+--no-detect-squash-merges         Only consider `strict` (fast-forward or 2-parent) merges, rather than rebase/squash merges, when detecting if a branch is merged into its upstream (parent).

--- a/docs/source/cli_help/traverse.rst
+++ b/docs/source/cli_help/traverse.rst
@@ -50,42 +50,34 @@ In other words, there is no need to explicitly ask to `continue` as it is the ca
 
 **Options:**
 
-  -F, --fetch                  Fetch the remotes of all managed branches at the beginning of traversal (no ``git pull`` involved, only ``git fetch``).
+-F, --fetch                  Fetch the remotes of all managed branches at the beginning of traversal (no ``git pull`` involved, only ``git fetch``).
 
-  -l, --list-commits           When printing the status, additionally list the messages of commits introduced on each branch.
+-l, --list-commits           When printing the status, additionally list the messages of commits introduced on each branch.
 
-  -M, --merge                  Update by merge rather than by rebase.
+-M, --merge                  Update by merge rather than by rebase.
 
-  -n                           If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
+-n                           If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
 
-  --no-detect-squash-merges    Only consider `strict` (fast-forward or 2-parent) merges, rather than rebase/squash merges,
-                               when detecting if a branch is merged into its upstream (parent).
+--no-detect-squash-merges    Only consider `strict` (fast-forward or 2-parent) merges, rather than rebase/squash merges, when detecting if a branch is merged into its upstream (parent).
 
-  --no-edit-merge              If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit flag`` to underlying ``git merge``).
-                               Not allowed if updating by rebase.
+--no-edit-merge              If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit flag`` to underlying ``git merge``). Not allowed if updating by rebase.
 
-  --no-interactive-rebase      If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag).
-                               Not allowed if updating by merge.
+--no-interactive-rebase      If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag). Not allowed if updating by merge.
 
-  --no-push                    Do not push any (neither tracked nor untracked) branches to remote, re-enable via ``--push``.
+--no-push                    Do not push any (neither tracked nor untracked) branches to remote, re-enable via ``--push``.
 
-  --no-push-untracked          Do not push untracked branches to remote, re-enable via ``--push-untracked``.
+--no-push-untracked          Do not push untracked branches to remote, re-enable via ``--push-untracked``.
 
-  --push                       Push all (both tracked and untracked) branches to remote --- default behavior.
+--push                       Push all (both tracked and untracked) branches to remote --- default behavior.
 
-  --push-untracked             Push untracked branches to remote --- default behavior.
+--push-untracked             Push untracked branches to remote --- default behavior.
 
-  --return-to=WHERE            Specifies the branch to return after traversal is successfully completed; WHERE can be ``here`` (the current branch at the moment when traversal starts),
-                               ``nearest-remaining`` (nearest remaining branch in case the ``here`` branch has been slid out by the traversal)
-                               or ``stay`` (the default --- just stay wherever the traversal stops).
-                               Note: when user quits by ``q``/``yq`` or when traversal is stopped because one of git actions fails, the behavior is always ``stay``.
+--return-to=WHERE            Specifies the branch to return after traversal is successfully completed; WHERE can be ``here`` (the current branch at the moment when traversal starts), ``nearest-remaining`` (nearest remaining branch in case the ``here`` branch has been slid out by the traversal) or ``stay`` (the default --- just stay wherever the traversal stops). Note: when user quits by ``q``/``yq`` or when traversal is stopped because one of git actions fails, the behavior is always ``stay``.
 
-  --start-from=WHERE           Specifies the branch to start the traversal from; WHERE can be ``here`` (the default --- current branch, must be managed by git machete),
-                               ``root`` (root branch of the current branch, as in ``git machete show root``) or ``first-root`` (first listed managed branch).
+--start-from=WHERE           Specifies the branch to start the traversal from; WHERE can be ``here`` (the default --- current branch, must be managed by git machete), ``root`` (root branch of the current branch, as in ``git machete show root``) or ``first-root`` (first listed managed branch).
 
-  -w, --whole                  Equivalent to ``-n --start-from=first-root`` --return-to=nearest-remaining;
-                               useful for quickly traversing & syncing all branches (rather than doing more fine-grained operations on the local section of the branch tree).
+-w, --whole                  Equivalent to ``-n --start-from=first-root`` --return-to=nearest-remaining; useful for quickly traversing & syncing all branches (rather than doing more fine-grained operations on the local section of the branch tree).
 
-  -W                           Equivalent to ``--fetch --whole``; useful for even more automated traversal of all branches.
+-W                           Equivalent to ``--fetch --whole``; useful for even more automated traversal of all branches.
 
-  -y, --yes                    Don't ask for any interactive input, including confirmation of rebase/push/pull. Implies ``-n``.
+-y, --yes                    Don't ask for any interactive input, including confirmation of rebase/push/pull. Implies ``-n``.

--- a/docs/source/cli_help/update.rst
+++ b/docs/source/cli_help/update.rst
@@ -18,15 +18,12 @@ If updating by merge, merges the upstream (parent) branch into the current branc
 
 **Options:**
 
-  -f, --fork-point=<fork-point-commit>    If updating by rebase, specifies the alternative fork point commit after which the rebased part of history is meant to start.
-                                          Not allowed if updating by merge.
+-f, --fork-point=<fork-point-commit>    If updating by rebase, specifies the alternative fork point commit after which the rebased part of history is meant to start. Not allowed if updating by merge.
 
-  -M, --merge                             Update by merge rather than by rebase.
+-M, --merge                             Update by merge rather than by rebase.
 
-  -n                                      If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
+-n                                      If updating by rebase, equivalent to ``--no-interactive-rebase``. If updating by merge, equivalent to ``--no-edit-merge``.
 
-  --no-edit-merge                         If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit`` flag to underlying ``git merge``).
-                                          Not allowed if updating by rebase.
+--no-edit-merge                         If updating by merge, skip opening the editor for merge commit message while doing ``git merge`` (i.e. pass ``--no-edit`` flag to underlying ``git merge``). Not allowed if updating by rebase.
 
-  --no-interactive-rebase                 If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag).
-                                          Not allowed if updating by merge.
+--no-interactive-rebase                 If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag). Not allowed if updating by merge.


### PR DESCRIPTION
Solution: I've removed double space at the beginning of each listed options. 

Extars: I've formatted some options descriptions, so they don't consist of multiple lines since they're displayed as they are one line anyway.