### PR TITLE
Issue #251: Remove direct run_git and popen_git calls from client.py.

### DIFF
--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1178,15 +1178,11 @@ class MacheteClient:
             return
 
         earliest_sha, earliest_short_sha, earliest_subject = commits[0]
-        earliest_full_body = self.__git.popen_git(
-            "log", "-1", "--format=%B", earliest_sha).strip()
+        earliest_full_body = self.__git.get_log("-1", "--format=%B", earliest_sha).strip()
         # %ai for ISO-8601 format; %aE/%aN for respecting .mailmap; see `git rev-list --help`
-        earliest_author_date = self.__git.popen_git(
-            "log", "-1", "--format=%ai", earliest_sha).strip()
-        earliest_author_email = self.__git.popen_git(
-            "log", "-1", "--format=%aE", earliest_sha).strip()
-        earliest_author_name = self.__git.popen_git(
-            "log", "-1", "--format=%aN", earliest_sha).strip()
+        earliest_author_date = self.__git.get_log("-1", "--format=%ai", earliest_sha).strip()
+        earliest_author_email = self.__git.get_log("-1", "--format=%aE", earliest_sha).strip()
+        earliest_author_name = self.__git.get_log("-1", "--format=%aN", earliest_sha).strip()
 
         # Following the convention of `git cherry-pick`, `git commit --amend`, `git rebase` etc.,
         # let's retain the original author (only committer will be overwritten).
@@ -1199,8 +1195,8 @@ class MacheteClient:
         # The tree (HEAD^{tree}) argument must be passed as first,
         # otherwise the entire `commit-tree` will fail on some ancient supported
         # versions of git (at least on v1.7.10).
-        squashed_sha = self.__git.popen_git(
-            "commit-tree", "HEAD^{tree}", "-p", fork_commit, "-m", earliest_full_body,
+        squashed_sha = self.__git.get_commit_tree(
+            "HEAD^{tree}", "-p", fork_commit, "-m", earliest_full_body,
             env=author_env).strip()
 
         # This can't be done with `git reset` since it doesn't allow for a custom reflog message.
@@ -1790,7 +1786,7 @@ class MacheteClient:
         debug(f'create_github_pr({head})', f'organization is {org}, repository is {repo}')
         debug(f'create_github_pr({head})', 'current GitHub user is ' + (current_user or '<none>'))
 
-        title: str = self.__git.popen_git("log", "-1", "--format=%s").strip()
+        title: str = self.__git.get_log("-1", "--format=%s").strip()
         description_path = self.__git.get_git_subpath('info', 'description')
         description: str = utils.slurp_file_or_empty(description_path)
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1043,9 +1043,9 @@ class MacheteClient:
         self.__git.display_diff(*params)
 
     def log(self, branch: str) -> None:
-        self.__git.display_log(
-            "^" + self.fork_point(branch, use_overrides=True),
-            f"refs/heads/{branch}")
+        full_branch_name = f"refs/heads{branch}"
+        forkpoint = self.fork_point(branch, use_overrides=True)
+        self.__git.display_branch_history_from_forkpoint(full_branch_name, forkpoint)
 
     def down(self, branch: str, pick_mode: bool) -> str:
         self.expect_in_managed_branches(branch)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1534,7 +1534,7 @@ class MacheteClient:
             ask_message = f"Push untracked branch {bold(branch)} to {bold(new_remote)}?" + choices
             ask_opt_yes_message = f"Pushing untracked branch {bold(branch)} to {bold(new_remote)}..."
             ans = self.ask_if(ask_message, ask_opt_yes_message,
-                              override_answer=None if self.__git.cli_opts.opt_push_untracked else "N")
+                              override_answer=None if self.__git._cli_opts.opt_push_untracked else "N")
             if is_called_from_traverse:
                 if ans in ('y', 'yes', 'yq'):
                     self.__git.push(new_remote, branch)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1199,7 +1199,8 @@ class MacheteClient:
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,
         # so the squashed commit would not even be considered to "belong"
         # (in the FP sense) to the current branch's history.
-        self.__git.update_ref("HEAD", squashed_sha, "-m", f"squash: {earliest_subject}")
+        self.__git.update_head_ref_to_new_hash_with_msg(
+            squashed_sha, f"squash: {earliest_subject}")
 
         print(f"Squashed {len(commits)} commits:")
         print()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -946,7 +946,7 @@ class MacheteClient:
                 opt_yes_msg = f"Deleting branch {msg_core}"
                 ans = self.ask_if(msg, opt_yes_msg)
                 if ans in ('y', 'yes'):
-                    self.__git.run_git("branch", "-d" if is_merged_to_remote else "-D", branch)
+                    self.__git.run_branch("-d" if is_merged_to_remote else "-D", branch)
                 elif ans in ('q', 'quit'):
                     return
 
@@ -957,7 +957,7 @@ class MacheteClient:
                 opt_yes_msg = f"Deleting branch {msg_core}"
                 ans = self.ask_if(msg, opt_yes_msg)
                 if ans in ('y', 'yes'):
-                    self.__git.run_git("branch", "-D", branch)
+                    self.__git.run_branch("-D", branch)
                 elif ans in ('q', 'quit'):
                     return
         else:
@@ -1040,11 +1040,10 @@ class MacheteClient:
             [fp] + \
             ([f"refs/heads/{branch}"] if branch else []) + \
             ["--"]
-        self.__git.run_git("diff", *params)
+        self.__git.run_diff(*params)
 
     def log(self, branch: str) -> None:
-        self.__git.run_git(
-            "log",
+        self.__git.run_log(
             "^" + self.fork_point(branch, use_overrides=True),
             f"refs/heads/{branch}")
 
@@ -1203,7 +1202,7 @@ class MacheteClient:
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,
         # so the squashed commit would not even be considered to "belong"
         # (in the FP sense) to the current branch's history.
-        self.__git.run_git("update-ref", "HEAD", squashed_sha, "-m", f"squash: {earliest_subject}")
+        self.__git.run_update_ref("HEAD", squashed_sha, "-m", f"squash: {earliest_subject}")
 
         print(f"Squashed {len(commits)} commits:")
         print()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1040,7 +1040,7 @@ class MacheteClient:
             [fp] + \
             ([f"refs/heads/{branch}"] if branch else []) + \
             ["--"]
-        self.__git.run_diff(*params)
+        self.__git.display_diff(*params)
 
     def log(self, branch: str) -> None:
         self.__git.display_log(
@@ -1202,7 +1202,7 @@ class MacheteClient:
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,
         # so the squashed commit would not even be considered to "belong"
         # (in the FP sense) to the current branch's history.
-        self.__git.run_update_ref("HEAD", squashed_sha, "-m", f"squash: {earliest_subject}")
+        self.__git.update_ref("HEAD", squashed_sha, "-m", f"squash: {earliest_subject}")
 
         print(f"Squashed {len(commits)} commits:")
         print()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1035,12 +1035,10 @@ class MacheteClient:
         fp: str = self.fork_point(
             branch if branch else self.__git.get_current_branch(),
             use_overrides=True)
-        params = \
-            (["--stat"] if self.__cli_opts.opt_stat else []) + \
-            [fp] + \
-            ([f"refs/heads/{branch}"] if branch else []) + \
-            ["--"]
-        self.__git.display_diff(*params)
+        self.__git.display_diff(
+            branch=branch,
+            forkpoint=fp,
+            format_with_stat=self.__cli_opts.opt_stat)
 
     def log(self, branch: str) -> None:
         full_branch_name = f"refs/heads{branch}"

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1194,9 +1194,8 @@ class MacheteClient:
         # The tree (HEAD^{tree}) argument must be passed as first,
         # otherwise the entire `commit-tree` will fail on some ancient supported
         # versions of git (at least on v1.7.10).
-        squashed_sha = self.__git.get_commit_tree(
-            "HEAD^{tree}", "-p", fork_commit, "-m", earliest_full_body,
-            env=author_env).strip()
+        squashed_sha = self.__git.squash_commits_with_msg_and_new_env(
+            fork_commit, earliest_full_body, author_env).strip()
 
         # This can't be done with `git reset` since it doesn't allow for a custom reflog message.
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -946,7 +946,7 @@ class MacheteClient:
                 opt_yes_msg = f"Deleting branch {msg_core}"
                 ans = self.ask_if(msg, opt_yes_msg)
                 if ans in ('y', 'yes'):
-                    self.__git.run_branch("-d" if is_merged_to_remote else "-D", branch)
+                    self.__git.delete_branch(branch, force=is_merged_to_remote)
                 elif ans in ('q', 'quit'):
                     return
 
@@ -957,7 +957,7 @@ class MacheteClient:
                 opt_yes_msg = f"Deleting branch {msg_core}"
                 ans = self.ask_if(msg, opt_yes_msg)
                 if ans in ('y', 'yes'):
-                    self.__git.run_branch("-D", branch)
+                    self.__git.delete_branch(branch, force=True)
                 elif ans in ('q', 'quit'):
                     return
         else:
@@ -1043,7 +1043,7 @@ class MacheteClient:
         self.__git.run_diff(*params)
 
     def log(self, branch: str) -> None:
-        self.__git.run_log(
+        self.__git.display_log(
             "^" + self.fork_point(branch, use_overrides=True),
             f"refs/heads/{branch}")
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1177,11 +1177,11 @@ class MacheteClient:
             return
 
         earliest_sha, earliest_short_sha, earliest_subject = commits[0]
-        earliest_full_body = self.__git.get_log("-1", "--format=%B", earliest_sha).strip()
+        earliest_full_body = self.__git.get_commit_information("raw body", earliest_sha).strip()
         # %ai for ISO-8601 format; %aE/%aN for respecting .mailmap; see `git rev-list --help`
-        earliest_author_date = self.__git.get_log("-1", "--format=%ai", earliest_sha).strip()
-        earliest_author_email = self.__git.get_log("-1", "--format=%aE", earliest_sha).strip()
-        earliest_author_name = self.__git.get_log("-1", "--format=%aN", earliest_sha).strip()
+        earliest_author_date = self.__git.get_commit_information("author date", earliest_sha).strip()
+        earliest_author_email = self.__git.get_commit_information("author email", earliest_sha).strip()
+        earliest_author_name = self.__git.get_commit_information("author name", earliest_sha).strip()
 
         # Following the convention of `git cherry-pick`, `git commit --amend`, `git rebase` etc.,
         # let's retain the original author (only committer will be overwritten).
@@ -1785,7 +1785,7 @@ class MacheteClient:
         debug(f'create_github_pr({head})', f'organization is {org}, repository is {repo}')
         debug(f'create_github_pr({head})', 'current GitHub user is ' + (current_user or '<none>'))
 
-        title: str = self.__git.get_log("-1", "--format=%s").strip()
+        title: str = self.__git.get_commit_information("subject").strip()
         description_path = self.__git.get_git_subpath('info', 'description')
         description: str = utils.slurp_file_or_empty(description_path)
 

--- a/git_machete/constants.py
+++ b/git_machete/constants.py
@@ -29,3 +29,11 @@ BEHIND_REMOTE = 3
 AHEAD_OF_REMOTE = 4
 DIVERGED_FROM_AND_OLDER_THAN_REMOTE = 5
 DIVERGED_FROM_AND_NEWER_THAN_REMOTE = 6
+
+GIT_FORMAT_PATTERNS = {
+    "author name": "%aN",
+    "author email": "%aE",
+    "author date": "%ai",
+    "raw body": "%B",
+    "subject": "%s"
+}

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -733,11 +733,11 @@ class GitContext:
             params.append(commit)
         return self._popen_git(*params)
 
-    def display_branch_history_from_forkpoint(self, branch: str, forkpoint: str):
+    def display_branch_history_from_forkpoint(self, branch: str, forkpoint: str) -> int:
         return self._run_git("log", f"^{forkpoint}", branch)
 
     def squash_commits_with_msg_and_new_env(
-            self, fork_commit: str, msg: str, env: dict) -> str:
+            self, fork_commit: str, msg: str, env: Dict[str, str]) -> str:
         # returns hash of the new commit
         return self._popen_git(
             "commit-tree", "HEAD^{tree}", "-p", fork_commit, "-m", msg, env=env)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -728,12 +728,10 @@ class GitContext:
                 " git-machete. Currently supported information are: "
                 f"{', '.join(GIT_FORMAT_PATTERNS.keys())}")
 
+        params = ["log", "-1", f"--format={GIT_FORMAT_PATTERNS[information]}"]
         if commit:
-            return self._popen_git(
-                "log", "-1", f"--format={GIT_FORMAT_PATTERNS[information]}", commit)
-        else:
-            return self._popen_git(
-                "log", "-1", f"--format={GIT_FORMAT_PATTERNS[information]}")
+            params.append(commit)
+        return self._popen_git(*params)
 
     def display_branch_history_from_forkpoint(self, branch: str, forkpoint: str):
         return self._run_git("log", f"^{forkpoint}", branch)
@@ -749,8 +747,16 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, branch_name)
 
-    def display_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:  # TODO
-        return self._run_git("diff", *args, **kwargs)
+    def display_diff(self, forkpoint, format_with_stat, branch = None) -> int:
+        params = ["diff"]
+        if format_with_stat:
+            params.append("--stat")
+        params.append(forkpoint)
+        if branch:
+            params.append(f"refs/heads/{branch}")
+        params.append("--")
+
+        return self._run_git(*params)
 
     def update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:  # TODO
         self.flush_caches()

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -735,9 +735,9 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, *args, **kwargs)
 
-    def run_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:
+    def display_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:
         return self._run_git("diff", *args, **kwargs)
 
-    def run_update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:
+    def update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:
         self.flush_caches()
         return self._run_git("update-ref", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Generator, Iterator, List, Match, Optional, Tuple, Set
+from typing import Callable, Dict, Generator, Iterator, List, Match, Optional, Set, Tuple
 
 import os
 import re
@@ -730,7 +730,7 @@ class GitContext:
         return self._popen_git("commit-tree", *args, **kwargs)
 
     def run_branch(self, *args: str, **kwargs: Dict[str, str]) -> int:
-        options_that_may_invalidate_cache: set = {'-d', "-D"}
+        options_that_may_invalidate_cache: Set[str] = {'-d', "-D"}
         if options_that_may_invalidate_cache.intersection(*args):
             self.flush_caches()
         return self._run_git("branch", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -720,24 +720,24 @@ class GitContext:
                     result[to_branch] = int(match.group(1))
         return result
 
-    def get_log(self, *args, **kwargs):
+    def get_log(self, *args: str, **kwargs: Dict[str, str]) -> str:
         return self._popen_git("log", *args, **kwargs)
 
-    def run_log(self, *args, **kwargs):
+    def run_log(self, *args: str, **kwargs: Dict[str, str]) -> int:
         return self._run_git("log", *args, **kwargs)
 
-    def get_commit_tree(self, *args, **kwargs):
+    def get_commit_tree(self, *args: str, **kwargs: Dict[str, str]) -> str:
         return self._popen_git("commit-tree", *args, **kwargs)
 
-    def run_branch(self, *args, **kwargs):
-        options_that_may_invalidate_cache = {'-d', "-D"}
-        if options_invalidation_cache.intersection(*args):
+    def run_branch(self, *args: str, **kwargs: Dict[str, str]) -> int:
+        options_that_may_invalidate_cache: set = {'-d', "-D"}
+        if options_that_may_invalidate_cache.intersection(*args):
             self.flush_caches()
         return self._run_git("branch", *args, **kwargs)
 
-    def run_diff(self, *args, **kwargs):
+    def run_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:
         return self._run_git("diff", *args, **kwargs)
 
-    def run_update_ref(self, *args, **kwargs):
+    def run_update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:
         self.flush_caches()
         return self._run_git("update-ref", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -747,7 +747,7 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, branch_name)
 
-    def display_diff(self, forkpoint, format_with_stat, branch = None) -> int:
+    def display_diff(self, forkpoint: str, format_with_stat: bool, branch: str= None) -> int:
         params = ["diff"]
         if format_with_stat:
             params.append("--stat")

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -747,7 +747,7 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, branch_name)
 
-    def display_diff(self, forkpoint: str, format_with_stat: bool, branch: str= None) -> int:
+    def display_diff(self, forkpoint: str, format_with_stat: bool, branch: str = None) -> int:
         params = ["diff"]
         if format_with_stat:
             params.append("--stat")

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -730,7 +730,7 @@ class GitContext:
         return self._popen_git("commit-tree", *args, **kwargs)
 
     def delete_branch(
-            self, *args: str, force: bool=False, **kwargs: Dict[str, str]) -> int:
+            self, *args: str, force: bool = False, **kwargs: Dict[str, str]) -> int:
         self.flush_caches()
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -723,17 +723,17 @@ class GitContext:
     def get_log(self, *args: str, **kwargs: Dict[str, str]) -> str:
         return self._popen_git("log", *args, **kwargs)
 
-    def run_log(self, *args: str, **kwargs: Dict[str, str]) -> int:
+    def display_log(self, *args: str, **kwargs: Dict[str, str]) -> int:
         return self._run_git("log", *args, **kwargs)
 
     def get_commit_tree(self, *args: str, **kwargs: Dict[str, str]) -> str:
         return self._popen_git("commit-tree", *args, **kwargs)
 
-    def run_branch(self, *args: str, **kwargs: Dict[str, str]) -> int:
-        options_that_may_invalidate_cache: Set[str] = {'-d', "-D"}
-        if options_that_may_invalidate_cache.intersection(*args):
-            self.flush_caches()
-        return self._run_git("branch", *args, **kwargs)
+    def delete_branch(
+            self, *args: str, force: bool=False, **kwargs: Dict[str, str]) -> int:
+        self.flush_caches()
+        delete_option = '-D' if force else '-d'
+        return self._run_git("branch", delete_option, *args, **kwargs)
 
     def run_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:
         return self._run_git("diff", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -738,8 +738,11 @@ class GitContext:
     def display_branch_history_from_forkpoint(self, branch: str, forkpoint: str):
         return self._run_git("log", f"^{forkpoint}", branch)
 
-    def get_commit_tree(self, *args: str, **kwargs: Dict[str, str]) -> str:  # TODO
-        return self._popen_git("commit-tree", *args, **kwargs)
+    def squash_commits_with_msg_and_new_env(
+            self, fork_commit: str, msg: str, env: dict) -> str:
+        # returns hash of the new commit
+        return self._popen_git(
+            "commit-tree", "HEAD^{tree}", "-p", fork_commit, "-m", msg, env=env)
 
     def delete_branch(self, branch_name: str, force: bool = False) -> int:
         self.flush_caches()

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -735,10 +735,10 @@ class GitContext:
             return self._popen_git(
                 "log", "-1", f"--format={GIT_FORMAT_PATTERNS[information]}")
 
-    def display_log(self, *args: str, **kwargs: Dict[str, str]) -> int:
-        return self._run_git("log", *args, **kwargs)
+    def display_branch_history_from_forkpoint(self, branch: str, forkpoint: str):
+        return self._run_git("log", f"^{forkpoint}", branch)
 
-    def get_commit_tree(self, *args: str, **kwargs: Dict[str, str]) -> str:
+    def get_commit_tree(self, *args: str, **kwargs: Dict[str, str]) -> str:  # TODO
         return self._popen_git("commit-tree", *args, **kwargs)
 
     def delete_branch(self, branch_name: str, force: bool = False) -> int:
@@ -746,9 +746,9 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git("branch", delete_option, branch_name)
 
-    def display_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:
+    def display_diff(self, *args: str, **kwargs: Dict[str, str]) -> int:  # TODO
         return self._run_git("diff", *args, **kwargs)
 
-    def update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:
+    def update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:  # TODO
         self.flush_caches()
         return self._run_git("update-ref", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -739,4 +739,5 @@ class GitContext:
         return self._run_git("diff", *args, **kwargs)
 
     def run_update_ref(self, *args, **kwargs):
+        self.flush_caches()
         return self._run_git("update-ref", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -47,7 +47,7 @@ class GitContext:
         return exit_code
 
     @staticmethod
-    def popen_git(git_cmd: str, *args: str, **kwargs: Dict[str, str]) -> str:
+    def _popen_git(git_cmd: str, *args: str, **kwargs: Dict[str, str]) -> str:
         exit_code, stdout, stderr = utils.popen_cmd("git", git_cmd, *args, **kwargs)
         if not kwargs.get("allow_non_zero") and exit_code != 0:
             exit_code_msg: str = fmt(f"`{utils.get_cmd_shell_repr('git', git_cmd, *args, **kwargs)}` returned {exit_code}\n")
@@ -102,14 +102,14 @@ class GitContext:
             # We need to cut out the x.y.z part and not just take the result of 'git version' as is,
             # because the version string in certain distributions of git (esp. on OS X) has an extra suffix,
             # which is irrelevant for our purpose (checking whether certain git CLI features are available/bugs are fixed).
-            raw = re.search(r"\d+.\d+.\d+", self.popen_git("version")).group(0)
+            raw = re.search(r"\d+.\d+.\d+", self._popen_git("version")).group(0)
             self.git_version = tuple(map(int, raw.split(".")))
         return self.git_version
 
     def get_root_dir(self) -> str:
         if not self.root_dir:
             try:
-                self.root_dir = self.popen_git("rev-parse", "--show-toplevel").strip()
+                self.root_dir = self._popen_git("rev-parse", "--show-toplevel").strip()
             except MacheteException:
                 raise MacheteException("Not a git repository")
         return self.root_dir
@@ -117,7 +117,7 @@ class GitContext:
     def __get_git_dir(self) -> str:
         if not self.git_dir:
             try:
-                self.git_dir = self.popen_git("rev-parse", "--git-dir").strip()
+                self.git_dir = self._popen_git("rev-parse", "--git-dir").strip()
             except MacheteException:
                 raise MacheteException("Not a git repository")
         return self.git_dir
@@ -127,14 +127,14 @@ class GitContext:
 
     def get_git_timespec_parsed_to_unix_timestamp(self, date: str) -> int:
         try:
-            return int(self.popen_git("rev-parse", "--since=" + date).replace("--max-age=", "").strip())
+            return int(self._popen_git("rev-parse", "--since=" + date).replace("--max-age=", "").strip())
         except (MacheteException, ValueError):
             raise MacheteException(f"Cannot parse timespec: `{date}`")
 
     def __ensure_config_loaded(self) -> None:
         if self.__config_cached is None:
             self.__config_cached = {}
-            for config_line in utils.get_non_empty_lines(self.popen_git("config", "--list")):
+            for config_line in utils.get_non_empty_lines(self._popen_git("config", "--list")):
                 k_v = config_line.split("=", 1)
                 if len(k_v) == 2:
                     k, v = k_v
@@ -157,11 +157,11 @@ class GitContext:
 
     def get_remotes(self) -> List[str]:
         if self.__remotes_cached is None:
-            self.__remotes_cached = utils.get_non_empty_lines(self.popen_git("remote"))
+            self.__remotes_cached = utils.get_non_empty_lines(self._popen_git("remote"))
         return self.__remotes_cached
 
     def get_url_of_remote(self, remote: str) -> str:
-        return self.popen_git("config", "--get", f"remote.{remote}.url").strip()  # 'git remote get-url' method has only been added in git v2.5.1
+        return self._popen_git("config", "--get", f"remote.{remote}.url").strip()  # 'git remote get-url' method has only been added in git v2.5.1
 
     def fetch_remote(self, remote: str) -> None:
         if remote not in self.__fetch_done_for:
@@ -200,7 +200,7 @@ class GitContext:
         self.flush_caches()
 
     def __find_short_commit_sha_by_revision(self, revision: str) -> str:
-        return self.popen_git("rev-parse", "--short", revision + "^{commit}").rstrip()
+        return self._popen_git("rev-parse", "--short", revision + "^{commit}").rstrip()
 
     def get_short_commit_sha_by_revision(self, revision: str) -> str:
         if revision not in self.__short_commit_sha_by_revision_cached:
@@ -211,7 +211,7 @@ class GitContext:
         # Without ^{commit}, 'git rev-parse --verify' will not only accept references to other kinds of objects (like trees and blobs),
         # but just echo the argument (and exit successfully) even if the argument doesn't match anything in the object store.
         try:
-            return self.popen_git("rev-parse", "--verify", "--quiet", revision + "^{commit}").rstrip()
+            return self._popen_git("rev-parse", "--verify", "--quiet", revision + "^{commit}").rstrip()
         except MacheteException:
             return None
 
@@ -225,7 +225,7 @@ class GitContext:
 
     def __find_tree_sha_by_revision(self, revision: str) -> Optional[str]:
         try:
-            return self.popen_git("rev-parse", "--verify", "--quiet", revision + "^{tree}").rstrip()
+            return self._popen_git("rev-parse", "--verify", "--quiet", revision + "^{tree}").rstrip()
         except MacheteException:
             return None
 
@@ -317,7 +317,7 @@ class GitContext:
         self.__tree_sha_by_commit_sha_cached = {}
 
         # Using 'committerdate:raw' instead of 'committerdate:unix' since the latter isn't supported by some older versions of git.
-        raw_remote = utils.get_non_empty_lines(self.popen_git("for-each-ref", "--format=%(refname)\t%(objectname)\t%(tree)\t%(committerdate:raw)", "refs/remotes"))
+        raw_remote = utils.get_non_empty_lines(self._popen_git("for-each-ref", "--format=%(refname)\t%(objectname)\t%(tree)\t%(committerdate:raw)", "refs/remotes"))
         for line in raw_remote:
             values = line.split("\t")
             if len(values) != 4:
@@ -329,7 +329,7 @@ class GitContext:
             self.__tree_sha_by_commit_sha_cached[commit_sha] = tree_sha
             self.__committer_unix_timestamp_by_revision_cached[branch] = int(committer_unix_timestamp_and_time_zone.split(' ')[0])
 
-        raw_local = utils.get_non_empty_lines(self.popen_git("for-each-ref", "--format=%(refname)\t%(objectname)\t%(tree)\t%(committerdate:raw)\t%(upstream)", "refs/heads"))
+        raw_local = utils.get_non_empty_lines(self._popen_git("for-each-ref", "--format=%(refname)\t%(objectname)\t%(tree)\t%(committerdate:raw)\t%(upstream)", "refs/heads"))
 
         for line in raw_local:
             values = line.split("\t")
@@ -347,7 +347,7 @@ class GitContext:
 
     def __get_log_shas(self, revision: str, max_count: Optional[int]) -> List[str]:
         opts = ([f"--max-count={str(max_count)}"] if max_count else []) + ["--format=%H", f"refs/heads/{revision}"]
-        return utils.get_non_empty_lines(self.popen_git("log", *opts))
+        return utils.get_non_empty_lines(self._popen_git("log", *opts))
 
     # Since getting the full history of a branch can be an expensive operation for large repositories (compared to all other underlying git operations),
     # there's a simple optimization in place: we first fetch only a couple of first commits in the history,
@@ -370,7 +370,7 @@ class GitContext:
         all_branches = [f"refs/heads/{branch}" for branch in self.get_local_branches()] + \
                        [f"refs/remotes/{self.get_combined_counterpart_for_fetching_of_branch(branch)}" for branch in self.get_local_branches() if self.get_combined_counterpart_for_fetching_of_branch(branch)]
         # The trailing '--' is necessary to avoid ambiguity in case there is a file called just exactly like one of the branches.
-        entries = utils.get_non_empty_lines(self.popen_git("reflog", "show", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])))
+        entries = utils.get_non_empty_lines(self._popen_git("reflog", "show", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])))
         self.__reflogs_cached = {}
         for entry in entries:
             values = entry.split("\t")
@@ -401,7 +401,7 @@ class GitContext:
                 self.__reflogs_cached[branch] = [
                     tuple(entry.split(":", 1)) for entry in utils.get_non_empty_lines(  # type: ignore
                         # The trailing '--' is necessary to avoid ambiguity in case there is a file called just exactly like the branch 'branch'.
-                        self.popen_git("reflog", "show", "--format=%H:%gs", branch, "--"))
+                        self._popen_git("reflog", "show", "--format=%H:%gs", branch, "--"))
                 ]
             return self.__reflogs_cached[branch]
 
@@ -460,7 +460,7 @@ class GitContext:
 
     def get_currently_checked_out_branch_or_none(self) -> Optional[str]:
         try:
-            raw = self.popen_git("symbolic-ref", "--quiet", "HEAD").strip()
+            raw = self._popen_git("symbolic-ref", "--quiet", "HEAD").strip()
             return re.sub("^refs/heads/", "", raw)
         except MacheteException:
             return None
@@ -503,7 +503,7 @@ class GitContext:
             #   then there is exactly one merge-base - the ancestor,
             # * if neither of sha1, sha2 is an ancestor of another,
             #   then none of the (possibly more than one) merge-bases is equal to either of sha1/sha2 anyway.
-            self.__merge_base_cached[sha1, sha2] = self.popen_git("merge-base", sha1, sha2).rstrip()
+            self.__merge_base_cached[sha1, sha2] = self._popen_git("merge-base", sha1, sha2).rstrip()
         return self.__merge_base_cached[sha1, sha2]
 
     # Note: the 'git rev-parse --verify' validation is not performed in case for either of earlier/later
@@ -551,7 +551,7 @@ class GitContext:
         # `git log later_commit_sha ^earlier_commit_sha`
         # shows all commits reachable from later_commit_sha but NOT from earlier_commit_sha
         intermediate_tree_shas = utils.get_non_empty_lines(
-            self.popen_git(
+            self._popen_git(
                 "log",
                 "--format=%T",  # full commit's tree hash
                 "^" + earlier_commit_sha,
@@ -579,7 +579,7 @@ class GitContext:
         return list(map(
             lambda branch: re.sub("^refs/heads/", "", branch),
             utils.get_non_empty_lines(
-                self.popen_git("for-each-ref", "--format=%(refname)", "--merged", "HEAD", "refs/heads"))
+                self._popen_git("for-each-ref", "--format=%(refname)", "--merged", "HEAD", "refs/heads"))
         ))
 
     def get_hook_path(self, hook_name: str) -> str:
@@ -668,7 +668,7 @@ class GitContext:
         return list(reversed(list(map(
             lambda x: tuple(x.split(":", 2)),  # type: ignore
             utils.get_non_empty_lines(
-                self.popen_git("log", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--"))
+                self._popen_git("log", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--"))
         ))))
 
     def get_relation_to_remote_counterpart(self, branch: str, remote_branch: str) -> int:
@@ -705,7 +705,7 @@ class GitContext:
         # %gd - reflog selector (HEAD@{<unix-timestamp> <time-zone>} for `--date=raw`;
         #   `--date=unix` is not available on some older versions of git)
         # %gs - reflog subject
-        output = self.popen_git("reflog", "show", "--format=%gd:%gs", "--date=raw")
+        output = self._popen_git("reflog", "show", "--format=%gd:%gs", "--date=raw")
         for entry in utils.get_non_empty_lines(output):
             pattern = "^HEAD@\\{([0-9]+) .+\\}:checkout: moving from (.+) to (.+)$"
             match = re.search(pattern, entry)
@@ -719,3 +719,9 @@ class GitContext:
                 if to_branch not in result:
                     result[to_branch] = int(match.group(1))
         return result
+
+    def get_log(self, *args, **kwargs):
+        return self._popen_git("log", *args, **kwargs)
+
+    def get_commit_tree(self, *args, **kwargs):
+        return self._popen_git("commit-tree", *args, **kwargs)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -758,6 +758,6 @@ class GitContext:
 
         return self._run_git(*params)
 
-    def update_ref(self, *args: str, **kwargs: Dict[str, str]) -> int:  # TODO
+    def update_head_ref_to_new_hash_with_msg(self, hash: str, msg: str) -> int:
         self.flush_caches()
-        return self._run_git("update-ref", *args, **kwargs)
+        return self._run_git("update-ref", "HEAD", hash, "-m", msg)


### PR DESCRIPTION
Things done:
1. Rename `run_git` to `_run_git` to discourage user from using this method outside of `GitContext` class
2. Rename `popen_git` to `_popen_git` to discourage user from using this method outside of `GitContext` class
3. Add methods to replace direct call of `run_git` in `client.py`. These methods are named `run_<git_command>`.
4. Add methods to replace direct call of `popen_git` in `client.py`. These methods are named `get_<git_command>`.

It looks a bit artificial, because now we have `get_log` and `run_log` methods. Is there any particular reason why we don't use always `popen_git` instead of `run_git`?

PR as draft until question above is answered, because decision of changing also that will have a major influence over the PR.