### PR TITLE
enforce correct shebags in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             set -x
             enforce-indent-two-spaces-outside-python.sh
             enforce-issue-number-for-todos.sh
+            enforce-correct-shebangs.sh
             ensure-completion-scripts-correct.sh
             ensure-links-correct.sh
             ensure-version-bumped.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
 
             PATH=./ci/checks:$PATH
             set -x
+            enforce-correct-shebangs.sh
             enforce-indent-two-spaces-outside-python.sh
             enforce-issue-number-for-todos.sh
-            enforce-correct-shebangs.sh
             ensure-completion-scripts-correct.sh
             ensure-links-correct.sh
             ensure-version-bumped.sh

--- a/ci/checks/enforce-correct-shebangs.sh
+++ b/ci/checks/enforce-correct-shebangs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+find ../../git_machete -type f -name "*.py" -exec sed -i '' 's/#!\/usr\/bin\/env python$/#!\/usr\/bin\/env python3/g;s/#!\/usr\/bin\/env python2$/#!\/usr\/bin\/env python3/g' {} \;

--- a/ci/checks/enforce-correct-shebangs.sh
+++ b/ci/checks/enforce-correct-shebangs.sh
@@ -2,4 +2,7 @@
 
 set -e -o pipefail -u
 
-find ../../git_machete -type f -name "*.py" -exec sed -i '' 's/#!\/usr\/bin\/env python$/#!\/usr\/bin\/env python3/g;s/#!\/usr\/bin\/env python2$/#!\/usr\/bin\/env python3/g' {} \;
+if grep -r -e '^#!\/usr\/bin\/env python$' -e '^#!\/usr\/bin\/env python2$' ../../git_machete; then
+  echo "Ambigous python shebang"
+  exit 1
+fi

--- a/ci/checks/enforce-correct-shebangs.sh
+++ b/ci/checks/enforce-correct-shebangs.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-if grep -r -e '^#!/usr/bin/env python$' -e '^#!/usr/bin/env python2$' git_machete; then
-  echo "Ambigouos python shebang, please declare shebangs that point to python3:  #!/usr/bin/env python3"
+if grep -r '^#!/usr/bin/env python2\?$' .; then
+  echo "Ambiguous python shebang, please declare shebangs that point to python3:  #!/usr/bin/env python3"
   exit 1
 fi

--- a/ci/checks/enforce-correct-shebangs.sh
+++ b/ci/checks/enforce-correct-shebangs.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-if grep -r -e '^#!\/usr\/bin\/env python$' -e '^#!\/usr\/bin\/env python2$' ../../git_machete; then
-  echo "Ambigous python shebang"
+if grep -r -e '^#!/usr/bin/env python$' -e '^#!/usr/bin/env python2$' git_machete; then
+  echo "Ambigouos python shebang, please declare shebangs that point to python3:  #!/usr/bin/env python3"
   exit 1
 fi

--- a/git-machete
+++ b/git-machete
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from git_machete import cli
 cli.main()

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 # Deliberately NOT using much more convenient `requests` to avoid external dependencies
 import http

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from git_machete import __version__
 from os import path


### PR DESCRIPTION
Initially i wanted to replace incorrect shebangs with `sed` in CI but there would be still unchanged ones left in repo, so maybe better to break CI when found? 