### PR TITLE
Remove messages returned by git in tests

### DIFF
--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -400,7 +400,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_branch_reappers_in_definition(self) -> None:
         body: str = \
             """master
@@ -420,7 +420,7 @@ class MacheteTester(unittest.TestCase):
             if e.parameter != expected_error_msg:
                 self.fail(f'Actual Exception message: {e} \nis not equal to expected message: {expected_error_msg}')
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -445,7 +445,7 @@ class MacheteTester(unittest.TestCase):
             "ignore-trailing"
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_traverse_no_push(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -480,7 +480,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_traverse_no_push_override(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -515,7 +515,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_traverse_no_push_untracked(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -550,7 +550,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_discover_traverse_squash(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -617,7 +617,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_slide_out(self) -> None:
         (
             self.repo_sandbox.new_branch("develop")
@@ -770,7 +770,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_squash_merge(self) -> None:
         (
             self.repo_sandbox.new_branch("root")
@@ -914,7 +914,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_help(self) -> None:
         self.launch_command("help")
         for (description, commands) in cli.command_groups:
@@ -931,7 +931,7 @@ class MacheteTester(unittest.TestCase):
                     else:
                         self.fail('SystemExit expected but not raised')
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_up(self) -> None:
         """Verify behaviour of a 'git machete go up' command.
 
@@ -965,7 +965,7 @@ class MacheteTester(unittest.TestCase):
                 "the parent/upstream branch of the current branch."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_down(self) -> None:
         """Verify behaviour of a 'git machete go down' command.
 
@@ -1000,7 +1000,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g d' performs 'git checkout' to "
                 "the child/downstream branch of the current branch.")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_first_root_with_downstream(self) -> None:
         """Verify behaviour of a 'git machete go first' command.
 
@@ -1052,7 +1052,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g d' performs 'git checkout' to "
                 "the child/downstream branch of the current branch.")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_first_root_without_downstream(self) -> None:
         """Verify behaviour of a 'git machete go first' command.
 
@@ -1085,7 +1085,7 @@ class MacheteTester(unittest.TestCase):
                 "if root branch has no downstream."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_last(self) -> None:
         """Verify behaviour of a 'git machete go last' command.
 
@@ -1135,7 +1135,7 @@ class MacheteTester(unittest.TestCase):
                 "has any downstream branches."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_next_successor_exists(self) -> None:
         """Verify behaviour of a 'git machete go next' command.
 
@@ -1179,7 +1179,7 @@ class MacheteTester(unittest.TestCase):
                 "config file if successor branch exists."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_next_successor_on_another_root_tree(self) -> None:
         """Verify behaviour of a 'git machete go next' command.
 
@@ -1215,7 +1215,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g n' can checkout to branch that doesn't"
                 "share root with the current branch.")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_prev_successor_exists(self) -> None:
         """Verify behaviour of a 'git machete go prev' command.
 
@@ -1258,7 +1258,7 @@ class MacheteTester(unittest.TestCase):
                 "when predecessor branch exists within the root tree."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_prev_successor_on_another_root_tree(self) -> None:
         """Verify behaviour of a 'git machete go prev' command.
 
@@ -1292,7 +1292,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g p' can checkout to branch that doesn't"
                 "share root with the current branch.")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_go_root(self) -> None:
         """Verify behaviour of a 'git machete go root' command.
 
@@ -1336,7 +1336,7 @@ class MacheteTester(unittest.TestCase):
                 "the root of the current branch."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_up(self) -> None:
         """Verify behaviour of a 'git machete show up' command.
 
@@ -1367,7 +1367,7 @@ class MacheteTester(unittest.TestCase):
                 "branch one above current one."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_down(self) -> None:
         """Verify behaviour of a 'git machete show down' command.
 
@@ -1398,7 +1398,7 @@ class MacheteTester(unittest.TestCase):
                 "a child/downstream branch one below current one."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_first(self) -> None:
         """Verify behaviour of a 'git machete show first' command.
 
@@ -1446,7 +1446,7 @@ class MacheteTester(unittest.TestCase):
                 "branch has any downstream branches."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_last(self) -> None:
         """Verify behaviour of a 'git machete show last' command.
 
@@ -1490,7 +1490,7 @@ class MacheteTester(unittest.TestCase):
                 "branch has any downstream branches."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_next(self) -> None:
         """Verify behaviour of a 'git machete show next' command.
 
@@ -1529,7 +1529,7 @@ class MacheteTester(unittest.TestCase):
                 "when successor branch exists within the root tree."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_prev(self) -> None:
         """Verify behaviour of a 'git machete show prev' command.
 
@@ -1567,7 +1567,7 @@ class MacheteTester(unittest.TestCase):
                 "when predecessor branch exists within the root tree."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_show_root(self) -> None:
         """Verify behaviour of a 'git machete show root' command.
 
@@ -1607,7 +1607,7 @@ class MacheteTester(unittest.TestCase):
                 "the current branch."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_advance_with_no_downstream_branches(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1627,7 +1627,7 @@ class MacheteTester(unittest.TestCase):
                     "has no downstream branches."):
             self.launch_command("advance")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_advance_with_one_downstream_branch(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1668,7 +1668,7 @@ class MacheteTester(unittest.TestCase):
                 "from the git-machete tree and the structure of the git machete "
                 "tree is updated.")
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_advance_with_few_possible_downstream_branches_and_yes_option(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1694,7 +1694,7 @@ class MacheteTester(unittest.TestCase):
                     "has more than one synchronized downstream branch."):
             self.launch_command("advance", '-y')
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_update_with_fork_point_not_specified(self) -> None:
         """Verify behaviour of a 'git machete update --no-interactive rebase' command.
 
@@ -1726,7 +1726,7 @@ class MacheteTester(unittest.TestCase):
                 "'git rebase' to the parent branch of the current branch."
         )
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     def test_update_with_fork_point_specified(self) -> None:
         """Verify behaviour of a 'git machete update --no-interactive rebase -f <commit_hash>' cmd.
 
@@ -1787,7 +1787,7 @@ class MacheteTester(unittest.TestCase):
         [{'head': {'ref': 'feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'root'}, 'number': '15',
           'html_url': 'www.github.com', 'state': 'open'}])
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     @mock.patch('urllib.request.Request', git_api_state_for_test_retarget_pr.new_request())
     @mock.patch('urllib.request.urlopen', MockContextManager)
     def test_retarget_pr(self) -> None:
@@ -1817,7 +1817,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'call-ws'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '31', 'html_url': 'www.github.com', 'state': 'open'}
     ])
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     @mock.patch('git_machete.github.derive_current_user_login', mock_derive_current_user_login)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
@@ -1888,7 +1888,7 @@ class MacheteTester(unittest.TestCase):
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com', 'state': 'open'}],
                                                           issues=[{'number': '4'}, {'number': '5'}, {'number': '6'}])
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
@@ -2065,7 +2065,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'bugfix/remove-n-option'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '5', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
@@ -2249,7 +2249,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'sphinx_export'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'comments/add_docstrings'}, 'number': '23', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
-    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs_freshly_cloned` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -8,6 +8,7 @@ import textwrap
 import time
 import unittest
 import subprocess
+import sys
 from contextlib import redirect_stdout, redirect_stderr
 from http import HTTPStatus
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -21,7 +22,7 @@ from git_machete.exceptions import MacheteException
 from git_machete.github import get_parsed_github_remote_url
 from git_machete.git_operations import GitContext
 from git_machete.options import CommandLineOptions
-from git_machete.utils import fmt
+from git_machete.utils import dim, fmt
 
 cli_opts: CommandLineOptions = CommandLineOptions()
 git: GitContext = GitContext(cli_opts)
@@ -33,6 +34,15 @@ def get_head_commit_hash() -> str:
     """Returns hash of a commit of the current branch head."""
     with os.popen("git rev-parse HEAD") as git_call:
         return git_call.read().strip()
+
+
+def mock_run_cmd(cmd: str, *args: str, **kwargs: Any) -> int:
+    completed_process: subprocess.CompletedProcess[bytes] = subprocess.run([cmd] + list(args), stdout=subprocess.PIPE,
+                                                                           stderr=subprocess.PIPE, **kwargs)
+    exit_code: int = completed_process.returncode
+    if exit_code != 0:
+        sys.stderr.write(dim(f"<exit code: {exit_code}>\n\n"))
+    return exit_code
 
 
 def mock_derive_current_user_login() -> str:
@@ -390,6 +400,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_branch_reappers_in_definition(self) -> None:
         body: str = \
             """master
@@ -409,6 +420,7 @@ class MacheteTester(unittest.TestCase):
             if e.parameter != expected_error_msg:
                 self.fail(f'Actual Exception message: {e} \nis not equal to expected message: {expected_error_msg}')
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -433,6 +445,7 @@ class MacheteTester(unittest.TestCase):
             "ignore-trailing"
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_traverse_no_push(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -467,6 +480,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_traverse_no_push_override(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -501,6 +515,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_traverse_no_push_untracked(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -535,6 +550,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_discover_traverse_squash(self) -> None:
         self.setup_discover_standard_tree()
 
@@ -601,6 +617,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_slide_out(self) -> None:
         (
             self.repo_sandbox.new_branch("develop")
@@ -753,6 +770,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_squash_merge(self) -> None:
         (
             self.repo_sandbox.new_branch("root")
@@ -896,6 +914,7 @@ class MacheteTester(unittest.TestCase):
             """,
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_help(self) -> None:
         self.launch_command("help")
         for (description, commands) in cli.command_groups:
@@ -912,6 +931,7 @@ class MacheteTester(unittest.TestCase):
                     else:
                         self.fail('SystemExit expected but not raised')
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_up(self) -> None:
         """Verify behaviour of a 'git machete go up' command.
 
@@ -945,6 +965,7 @@ class MacheteTester(unittest.TestCase):
                 "the parent/upstream branch of the current branch."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_down(self) -> None:
         """Verify behaviour of a 'git machete go down' command.
 
@@ -979,6 +1000,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g d' performs 'git checkout' to "
                 "the child/downstream branch of the current branch.")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_first_root_with_downstream(self) -> None:
         """Verify behaviour of a 'git machete go first' command.
 
@@ -1030,6 +1052,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g d' performs 'git checkout' to "
                 "the child/downstream branch of the current branch.")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_first_root_without_downstream(self) -> None:
         """Verify behaviour of a 'git machete go first' command.
 
@@ -1062,6 +1085,7 @@ class MacheteTester(unittest.TestCase):
                 "if root branch has no downstream."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_last(self) -> None:
         """Verify behaviour of a 'git machete go last' command.
 
@@ -1111,6 +1135,7 @@ class MacheteTester(unittest.TestCase):
                 "has any downstream branches."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_next_successor_exists(self) -> None:
         """Verify behaviour of a 'git machete go next' command.
 
@@ -1154,6 +1179,7 @@ class MacheteTester(unittest.TestCase):
                 "config file if successor branch exists."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_next_successor_on_another_root_tree(self) -> None:
         """Verify behaviour of a 'git machete go next' command.
 
@@ -1189,6 +1215,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g n' can checkout to branch that doesn't"
                 "share root with the current branch.")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_prev_successor_exists(self) -> None:
         """Verify behaviour of a 'git machete go prev' command.
 
@@ -1231,6 +1258,7 @@ class MacheteTester(unittest.TestCase):
                 "when predecessor branch exists within the root tree."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_prev_successor_on_another_root_tree(self) -> None:
         """Verify behaviour of a 'git machete go prev' command.
 
@@ -1264,6 +1292,7 @@ class MacheteTester(unittest.TestCase):
             msg="Verify that 'git machete g p' can checkout to branch that doesn't"
                 "share root with the current branch.")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_go_root(self) -> None:
         """Verify behaviour of a 'git machete go root' command.
 
@@ -1307,6 +1336,7 @@ class MacheteTester(unittest.TestCase):
                 "the root of the current branch."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_up(self) -> None:
         """Verify behaviour of a 'git machete show up' command.
 
@@ -1337,6 +1367,7 @@ class MacheteTester(unittest.TestCase):
                 "branch one above current one."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_down(self) -> None:
         """Verify behaviour of a 'git machete show down' command.
 
@@ -1367,6 +1398,7 @@ class MacheteTester(unittest.TestCase):
                 "a child/downstream branch one below current one."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_first(self) -> None:
         """Verify behaviour of a 'git machete show first' command.
 
@@ -1414,6 +1446,7 @@ class MacheteTester(unittest.TestCase):
                 "branch has any downstream branches."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_last(self) -> None:
         """Verify behaviour of a 'git machete show last' command.
 
@@ -1457,6 +1490,7 @@ class MacheteTester(unittest.TestCase):
                 "branch has any downstream branches."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_next(self) -> None:
         """Verify behaviour of a 'git machete show next' command.
 
@@ -1495,6 +1529,7 @@ class MacheteTester(unittest.TestCase):
                 "when successor branch exists within the root tree."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_prev(self) -> None:
         """Verify behaviour of a 'git machete show prev' command.
 
@@ -1532,6 +1567,7 @@ class MacheteTester(unittest.TestCase):
                 "when predecessor branch exists within the root tree."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_show_root(self) -> None:
         """Verify behaviour of a 'git machete show root' command.
 
@@ -1571,6 +1607,7 @@ class MacheteTester(unittest.TestCase):
                 "the current branch."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_advance_with_no_downstream_branches(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1590,6 +1627,7 @@ class MacheteTester(unittest.TestCase):
                     "has no downstream branches."):
             self.launch_command("advance")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_advance_with_one_downstream_branch(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1630,6 +1668,7 @@ class MacheteTester(unittest.TestCase):
                 "from the git-machete tree and the structure of the git machete "
                 "tree is updated.")
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_advance_with_few_possible_downstream_branches_and_yes_option(self) -> None:
         """Verify behaviour of a 'git machete advance' command.
 
@@ -1655,6 +1694,7 @@ class MacheteTester(unittest.TestCase):
                     "has more than one synchronized downstream branch."):
             self.launch_command("advance", '-y')
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_update_with_fork_point_not_specified(self) -> None:
         """Verify behaviour of a 'git machete update --no-interactive rebase' command.
 
@@ -1686,6 +1726,7 @@ class MacheteTester(unittest.TestCase):
                 "'git rebase' to the parent branch of the current branch."
         )
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     def test_update_with_fork_point_specified(self) -> None:
         """Verify behaviour of a 'git machete update --no-interactive rebase -f <commit_hash>' cmd.
 
@@ -1746,6 +1787,7 @@ class MacheteTester(unittest.TestCase):
         [{'head': {'ref': 'feature'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'root'}, 'number': '15',
           'html_url': 'www.github.com', 'state': 'open'}])
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     @mock.patch('urllib.request.Request', git_api_state_for_test_retarget_pr.new_request())
     @mock.patch('urllib.request.urlopen', MockContextManager)
     def test_retarget_pr(self) -> None:
@@ -1775,6 +1817,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'call-ws'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '31', 'html_url': 'www.github.com', 'state': 'open'}
     ])
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     @mock.patch('git_machete.github.derive_current_user_login', mock_derive_current_user_login)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_anno_prs.new_request())
@@ -1845,6 +1888,7 @@ class MacheteTester(unittest.TestCase):
     git_api_state_for_test_create_pr = MockGithubAPIState([{'head': {'ref': 'ignore-trailing'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'hotfix/add-trigger'}, 'number': '3', 'html_url': 'www.github.com', 'state': 'open'}],
                                                           issues=[{'number': '4'}, {'number': '5'}, {'number': '6'}])
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('urllib.request.urlopen', MockContextManager)
     @mock.patch('urllib.request.Request', git_api_state_for_test_create_pr.new_request())
@@ -2021,6 +2065,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'bugfix/remove-n-option'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'develop'}, 'number': '5', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
@@ -2204,6 +2249,7 @@ class MacheteTester(unittest.TestCase):
         {'head': {'ref': 'sphinx_export'}, 'user': {'login': 'github_user'}, 'base': {'ref': 'comments/add_docstrings'}, 'number': '23', 'html_url': 'www.github.com', 'state': 'closed'}
     ])
 
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)
     # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_checkout_prs_freshly_cloned` due to `git fetch` executed by `checkout-prs` subcommand.
     @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
     @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)


### PR DESCRIPTION
Closes #207

But the current solution has pretty big con: any output from git will be removed from git_machete everywhere, so in normal flow the user will not able to see for egz: `Switched to branch 'develop'`. Those messages will be outputted when returncode is not 0.

Was there a specific reason to use `subprocess.call` in `run_cmd`? AFAICS `call` i equivalent to  `subprocess.run(...).returncode` and `run` calls `Popen` underneath anyway.

Another way to remove spam would be  just to  mock `run_cmd` from utils module.

So, main question is to capture all stdout/err or just mock it in tests?
