### PR TITLE
Issue #169: Enforce that fork-point options values have to be ancestors of branch.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.5.0
 
 - added: new way of acquiring the github token (from the file in `~`)
+- fixed: fork-point and down-fork-point options values have to be ancestor of the current branch
 
 ## New in git-machete 3.4.0
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -655,6 +655,9 @@ def launch(orig_args: List[str]) -> None:
             machete_client.read_definition_file()
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
+            if "fork_point" in parsed_cli:
+                git.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(
+                    forkpoint_sha=cli_opts.opt_fork_point, branch=current_branch)
             git.rebase_onto_ancestor_commit(
                 current_branch,
                 cli_opts.opt_fork_point or machete_client.fork_point(
@@ -683,6 +686,9 @@ def launch(orig_args: List[str]) -> None:
             machete_client.read_definition_file()
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
+            if "fork_point" in parsed_cli:
+                git.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(
+                    forkpoint_sha=cli_opts.opt_fork_point, branch=current_branch)
             machete_client.squash(
                 current_branch,
                 cli_opts.opt_fork_point or machete_client.fork_point(
@@ -706,6 +712,9 @@ def launch(orig_args: List[str]) -> None:
         elif cmd == "update":
             machete_client.read_definition_file()
             git.expect_no_operation_in_progress()
+            if "fork_point" in parsed_cli:
+                git.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(
+                    forkpoint_sha=cli_opts.opt_fork_point, branch=git.get_current_branch())
             machete_client.update()
         elif cmd == "version":
             version()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -474,6 +474,20 @@ class MacheteClient:
             if not new_upstream:
                 raise MacheteException(f"No upstream branch defined for `{branch}`, cannot slide out")
 
+        if self.__cli_opts.opt_down_fork_point:
+            last_branch_to_slide_out = branches_to_slide_out[-1]
+            children_of_the_last_branch_to_slide_out = self.__down_branches.get(
+                last_branch_to_slide_out)
+
+            if len(children_of_the_last_branch_to_slide_out) > 1:
+                raise MacheteException(
+                    "Last branch to slide out can't have more than one child branch "
+                    "if option `--down-fork-point` is passed.")
+
+            self.__git.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(
+                forkpoint_sha=self.__cli_opts.opt_down_fork_point,
+                branch=children_of_the_last_branch_to_slide_out[0])
+
         # Verify that all "interior" slide-out branches have a single downstream
         # pointing to the next slide-out
         for bu, bd in zip(branches_to_slide_out[:-1], branches_to_slide_out[1:]):

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -527,8 +527,12 @@ class GitContext:
         earlier_sha = self.get_full_sha(earlier_revision, earlier_prefix)
         later_sha = self.get_full_sha(later_revision, later_prefix)
 
+        # This if statement is not changing the outcome of the later return, but
+        # it enhances the efficiency of the script. If both hashes are the same,
+        # there is no point running git merge-base.
         if earlier_sha == later_sha:
             return True
+
         return self.__get_merge_base(earlier_sha, later_sha) == earlier_sha
 
     # Determine if later_revision, or any ancestors of later_revision that are NOT ancestors of earlier_revision,
@@ -769,3 +773,13 @@ class GitContext:
     def update_head_ref_to_new_hash_with_msg(self, hash: str, msg: str) -> int:
         self.flush_caches()
         return self._run_git("update-ref", "HEAD", hash, "-m", msg)
+
+    def check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(
+            self, forkpoint_sha: str, branch: str) -> None:
+        if not self.is_ancestor_or_equal(
+                earlier_revision=forkpoint_sha,
+                earlier_prefix='',
+                later_revision=branch):
+            raise MacheteException(
+                f"Forkpoint {forkpoint_sha} is not ancestor of or the tip "
+                f"of the {branch} branch.")


### PR DESCRIPTION
I'm not in love with this solution, because `slide-out` is handling this validation in different place than `reapply`, `squash` and `update`.

It makes sense at the current state of the repo that this validation would be taken care of in the `cli.py`, because there are already some other validation like that there. Unfortunately for `slide-out` I need to know what child branches are connected with the last passed branch and to do that I'm using "superprivate" (`double _`) `MacheteClient` variable that stores this information (`__down_branches: dict`).