### PR TITLE
[Blocked by release v3.4.0] Run `git fetch --prune` in all contexts

### DIFF
--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -170,7 +170,7 @@ class GitContext:
 
     def fetch_remote(self, remote: str) -> None:
         if remote not in self.__fetch_done_for:
-            self._run_git("fetch", remote)
+            self._run_git("fetch", remote, '--prune')  # --prune added to remove remote branches that are already deleted from remote
             self.__fetch_done_for.add(remote)
             self.flush_caches()
 

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -170,7 +170,7 @@ class GitContext:
 
     def fetch_remote(self, remote: str) -> None:
         if remote not in self.__fetch_done_for:
-            self._run_git("fetch", remote, '--prune')  # --prune added to remove remote branches that are already deleted from remote
+            self._run_git("fetch", remote, "--prune")  # --prune added to remove remote branches that are already deleted from remote
             self.__fetch_done_for.add(remote)
             self.flush_caches()
 


### PR DESCRIPTION
closes #243.

Except adding `--prune` flag to `git fetch` I don't see anything left to be changed.