### PR TITLE
Issue #345: Better handling of error messages from `UnprocessableEntityError`

### DIFF
--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -125,6 +125,19 @@ def __get_github_token() -> Optional[str]:
             get_token_from_hub())
 
 
+def __exctract_failure_info_from_422(response: Any) -> str:
+    if response['message'] != 'Validation Failed':
+        return str(response['message'])
+    ret: List[str] = []
+    if response.get('errors'):
+        for error in response['errors']:
+            if error.get('message'):
+                ret.append(error['message'])
+    if ret:
+        return '\n'.join(ret)
+    return str(response)
+
+
 def __fire_github_api_request(method: str, path: str, token: Optional[str], request_body: Optional[Dict[str, Any]] = None) -> Any:
     headers: Dict[str, str] = {
         'Content-type': 'application/json',
@@ -148,7 +161,7 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
     except HTTPError as err:
         if err.code == http.HTTPStatus.UNPROCESSABLE_ENTITY:
             error_response = json.loads(err.read().decode())
-            error_reason: str = exctract_failure_info_from_422(error_response)
+            error_reason: str = __exctract_failure_info_from_422(error_response)
             raise UnprocessableEntityHTTPError(error_reason)
         elif err.code in (http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN):
             first_line = f'GitHub API returned {err.code} HTTP status with error message: `{err.reason}`\n'
@@ -267,16 +280,3 @@ def get_pull_request_by_number_or_none(number: int, org: str, repo: str) -> Opti
 def checkout_pr_refs(git: GitContext, remote: str, pr_number: int, branch: LocalBranchShortName) -> None:
     git.fetch_ref(remote, f'pull/{pr_number}/head:{branch}')
     git.checkout(branch)
-
-
-def exctract_failure_message_from_422(response: Any) -> str:
-    if response['message'] != 'Validation Failed':
-        return response['message']
-    ret: List[str] = []
-    if response.get('errors'):
-        for error in response['errors']:
-            if error.get('message'):
-                ret.append(error['message'])
-    if ret:
-        return '\n'.join(ret)
-    return str(response)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -148,7 +148,7 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
     except HTTPError as err:
         if err.code == http.HTTPStatus.UNPROCESSABLE_ENTITY:
             error_response = json.loads(err.read().decode())
-            error_reason: str = error_response['errors'][0]['message']
+            error_reason: str = exctract_failure_info_from_422(error_response)
             raise UnprocessableEntityHTTPError(error_reason)
         elif err.code in (http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN):
             first_line = f'GitHub API returned {err.code} HTTP status with error message: `{err.reason}`\n'
@@ -267,3 +267,16 @@ def get_pull_request_by_number_or_none(number: int, org: str, repo: str) -> Opti
 def checkout_pr_refs(git: GitContext, remote: str, pr_number: int, branch: LocalBranchShortName) -> None:
     git.fetch_ref(remote, f'pull/{pr_number}/head:{branch}')
     git.checkout(branch)
+
+
+def exctract_failure_message_from_422(response: Any) -> str:
+    if response['message'] != 'Validation Failed':
+        return response['message']
+    ret: List[str] = []
+    if response.get('errors'):
+        for error in response['errors']:
+            if error.get('message'):
+                ret.append(error['message'])
+    if ret:
+        return '\n'.join(ret)
+    return str(response)

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -125,7 +125,7 @@ def __get_github_token() -> Optional[str]:
             get_token_from_hub())
 
 
-def __exctract_failure_info_from_422(response: Any) -> str:
+def __extract_failure_info_from_422(response: Any) -> str:
     if response['message'] != 'Validation Failed':
         return str(response['message'])
     ret: List[str] = []
@@ -161,7 +161,7 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
     except HTTPError as err:
         if err.code == http.HTTPStatus.UNPROCESSABLE_ENTITY:
             error_response = json.loads(err.read().decode())
-            error_reason: str = __exctract_failure_info_from_422(error_response)
+            error_reason: str = __extract_failure_info_from_422(error_response)
             raise UnprocessableEntityHTTPError(error_reason)
         elif err.code in (http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN):
             first_line = f'GitHub API returned {err.code} HTTP status with error message: `{err.reason}`\n'


### PR DESCRIPTION
closes #345 

does not fully close #177, as there should be info served how to force git-machete not to add reviewers. 
Draft, because there is still open point what to do when no relevant message is received, currently print all the response. 