### PR TITLE
Fix start-from CLI arg

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -427,7 +427,7 @@ def update_cli_opts_using_parsed_args(
             cli_opts.opt_return_to = arg
         elif opt == "stat":
             cli_opts.opt_stat = True
-        elif opt == "start-from":
+        elif opt == "start_from":
             cli_opts.opt_start_from = arg
         elif opt == "sync_github_prs":
             cli_opts.opt_sync_github_prs = True

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -332,7 +332,7 @@ def create_cli_parser() -> argparse.ArgumentParser:
     traverse_parser.add_argument('--push-untracked', action='store_true')
     traverse_parser.add_argument('--no-push-untracked', action='store_true')
     traverse_parser.add_argument('--return-to')
-    traverse_parser.add_argument('--start_from')
+    traverse_parser.add_argument('--start-from')
     traverse_parser.add_argument('-w', '--whole', action='store_true')
     traverse_parser.add_argument('-W', action='store_true')
     traverse_parser.add_argument('-y', '--yes', action='store_true')
@@ -427,7 +427,7 @@ def update_cli_opts_using_parsed_args(
             cli_opts.opt_return_to = arg
         elif opt == "stat":
             cli_opts.opt_stat = True
-        elif opt == "start_from":
+        elif opt == "start-from":
             cli_opts.opt_start_from = arg
         elif opt == "sync_github_prs":
             cli_opts.opt_sync_github_prs = True


### PR DESCRIPTION
https://github.com/VirtusLab/git-machete/pull/229 incorrectly renamed the arg `--start-from` to `--start_from` which doesn't match any of the docs. Looks like it was a replace-all gone wrong, this PR changes it back to `--start-from`

Output after a fresh install on Ubuntu 20.04:
```
jyap@:~/Documents/git-machete (master)$ git machete traverse --start-from=root
usage: git machete [--debug] [-h] [--version] [-v]
                   {add,advance,anno,delete-unmanaged,diff,d,discover,edit,e,file,fork-point,format,github,go,g,help,hooks,is-managed,list,log,l,reapply,show,slide-out,squash,status,s,traverse,update,version}
                   ...
git machete: error: unrecognized arguments: --start-from=root
jyap@:~/Documents/git-machete (master)$ git machete --version
git machete version 3.5.0
jyap@:~/Documents/git-machete (master)$ git machete traverse --start_from=root

No branches listed in .git/machete; use git machete discover or git machete edit, or edit .git/machete manually.
```