### PR TITLE
issue #:312Remove `yq` installation from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,6 @@ jobs:
 
             # For ensure-links-correct.sh
             npm install --global remark-cli remark-lint-no-dead-urls remark-validate-links
-
-            # For the scripts doing `docker-compose pull` to work around https://github.com/docker/compose/issues/7258
-            # wget -q https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64
-            # sudo mv yq_linux_amd64 /usr/local/bin/yq
-            # sudo chmod +x /usr/local/bin/yq
       - run:
           name: Perform initial checks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
             npm install --global remark-cli remark-lint-no-dead-urls remark-validate-links
 
             # For the scripts doing `docker-compose pull` to work around https://github.com/docker/compose/issues/7258
-            wget -q https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64
-            sudo mv yq_linux_amd64 /usr/local/bin/yq
-            sudo chmod +x /usr/local/bin/yq
+            # wget -q https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64
+            # sudo mv yq_linux_amd64 /usr/local/bin/yq
+            # sudo chmod +x /usr/local/bin/yq
       - run:
           name: Perform initial checks
           command: |
@@ -187,6 +187,7 @@ workflows:
               only:
                 - "develop"
                 - "/hotfix.*/"
+                - "/remove.*/"
           requires:
             *mandatory_jobs
       - deploy from master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,6 @@ workflows:
               only:
                 - "develop"
                 - "/hotfix.*/"
-                - "/remove.*/"
           requires:
             *mandatory_jobs
       - deploy from master:


### PR DESCRIPTION
closes #312

Indeed `yq` isntallation is no longer needed as without it everything runs smoothly.
A Job with dry runs and disabled `yq`:
https://app.circleci.com/pipelines/github/VirtusLab/git-machete/1144/workflows/439ab1b6-39a1-4a13-8d25-04adfe175157/jobs/3972
(or build 1144 in CircleCI)