### PR TITLE
Issue #443: git-machete should NOT always interactively ask about sliding out non-existent branches

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -531,8 +531,9 @@ def launch(orig_args: List[str]) -> None:
                     f"{machete_client.definition_file_path} is a directory "
                     "rather than a regular file, aborting")
 
+        perform_interactive_slide_out_flag = perform_interactive_slide_out(cmd)
         if cmd == "add":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             machete_client.add(
                 branch=branch,
@@ -540,13 +541,13 @@ def launch(orig_args: List[str]) -> None:
                 opt_as_root=cli_opts.opt_as_root,
                 opt_yes=cli_opts.opt_yes)
         elif cmd == "advance":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             machete_client.expect_in_managed_branches(current_branch)
             machete_client.advance(branch=current_branch, opt_yes=cli_opts.opt_yes)
         elif cmd == "anno":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd),
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag,
                                                 verify_branches=False)
             if cli_opts.opt_sync_github_prs:
                 machete_client.sync_annotations_to_github_prs()
@@ -558,10 +559,10 @@ def launch(orig_args: List[str]) -> None:
                 else:
                     machete_client.print_annotation(branch)
         elif cmd == "delete-unmanaged":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             machete_client.delete_unmanaged(opt_yes=cli_opts.opt_yes)
         elif cmd in {"diff", alias_by_command["diff"]}:
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             machete_client.diff(branch=parsed_cli.branch, opt_stat=cli_opts.opt_stat)  # passing None if not specified
         elif cmd == "discover":
             # No need to read definition file.
@@ -577,7 +578,7 @@ def launch(orig_args: List[str]) -> None:
             # No need to read definition file.
             print(os.path.abspath(machete_client.definition_file_path))
         elif cmd == "fork-point":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             if cli_opts.opt_inferred:
                 print(machete_client.fork_point(
@@ -607,7 +608,7 @@ def launch(orig_args: List[str]) -> None:
                     use_overrides=True,
                     opt_no_detect_squash_merges=cli_opts.opt_no_detect_squash_merges))
         elif cmd in {"go", alias_by_command["go"]}:
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             dest = machete_client.parse_direction(
@@ -616,7 +617,7 @@ def launch(orig_args: List[str]) -> None:
                 git.checkout(dest)
         elif cmd == "github":
             github_subcommand = parsed_cli.subcommand
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
 
             if 'draft' in parsed_cli and github_subcommand != 'create-pr':
                 raise MacheteException("'--draft' option is only valid with 'create-pr' subcommand.")
@@ -647,7 +648,7 @@ def launch(orig_args: List[str]) -> None:
                 machete_client.expect_in_managed_branches(current_branch)
                 machete_client.retarget_github_pr(current_branch)
         elif cmd == "is-managed":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             if branch is None or branch not in machete_client.managed_branches:
                 exit_script(1)
@@ -660,7 +661,7 @@ def launch(orig_args: List[str]) -> None:
                 raise MacheteException(
                     f"`git machete list {category}` does not expect extra arguments")
 
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             res = []
             if category == "addable":
                 def strip_remote_name(remote_branch: RemoteBranchShortName) -> LocalBranchShortName:
@@ -691,11 +692,11 @@ def launch(orig_args: List[str]) -> None:
             if res:
                 print("\n".join(res))
         elif cmd in {"log", alias_by_command["log"]}:
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             machete_client.log(branch)
         elif cmd == "reapply":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             if "fork_point" in parsed_cli:
@@ -717,7 +718,7 @@ def launch(orig_args: List[str]) -> None:
                         '`show current` with a <branch> argument does not make sense')
                 print(branch)
             else:
-                machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd),
+                machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag,
                                                     verify_branches=False)
                 print(
                     '\n'.join(machete_client.parse_direction(
@@ -728,7 +729,7 @@ def launch(orig_args: List[str]) -> None:
                     ))
                 )
         elif cmd == "slide-out":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             branches = parsed_cli_as_dict.get('branches', [git.get_current_branch()])
             machete_client.slide_out(
@@ -738,7 +739,7 @@ def launch(orig_args: List[str]) -> None:
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase,
                 opt_no_edit_merge=cli_opts.opt_no_edit_merge)
         elif cmd == "squash":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             if "fork_point" in parsed_cli:
@@ -751,7 +752,7 @@ def launch(orig_args: List[str]) -> None:
                     use_overrides=True,
                     opt_no_detect_squash_merges=cli_opts.opt_no_detect_squash_merges))
         elif cmd in {"status", alias_by_command["status"]}:
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             machete_client.expect_at_least_one_managed_branch()
             machete_client.status(
                 warn_on_yellow_edges=True,
@@ -767,7 +768,7 @@ def launch(orig_args: List[str]) -> None:
                 raise MacheteException(
                     "Invalid argument for `--return-to`. "
                     "Valid arguments: `here|nearest-remaining|stay`.")
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             machete_client.traverse(
                 opt_fetch=cli_opts.opt_fetch,
@@ -782,7 +783,7 @@ def launch(orig_args: List[str]) -> None:
                 opt_start_from=cli_opts.opt_start_from,
                 opt_yes=cli_opts.opt_yes)
         elif cmd == "update":
-            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out_flag)
             git.expect_no_operation_in_progress()
             if "fork_point" in parsed_cli:
                 machete_client.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -15,7 +15,7 @@ from git_machete.constants import EscapeCodes
 from git_machete.docs import short_docs, long_docs
 from git_machete.exceptions import MacheteException, StopInteraction
 from git_machete.git_operations import AnyRevision, GitContext, LocalBranchShortName, RemoteBranchShortName
-from git_machete.utils import fmt, underline, excluding, warn
+from git_machete.utils import fmt, perform_interactive_slide_out, underline, excluding, warn
 
 T = TypeVar('T')
 
@@ -532,7 +532,7 @@ def launch(orig_args: List[str]) -> None:
                     "rather than a regular file, aborting")
 
         if cmd == "add":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             machete_client.add(
                 branch=branch,
@@ -540,13 +540,14 @@ def launch(orig_args: List[str]) -> None:
                 opt_as_root=cli_opts.opt_as_root,
                 opt_yes=cli_opts.opt_yes)
         elif cmd == "advance":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             machete_client.expect_in_managed_branches(current_branch)
             machete_client.advance(branch=current_branch, opt_yes=cli_opts.opt_yes)
         elif cmd == "anno":
-            machete_client.read_definition_file(verify_branches=False)
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd),
+                                                verify_branches=False)
             if cli_opts.opt_sync_github_prs:
                 machete_client.sync_annotations_to_github_prs()
             else:
@@ -557,10 +558,10 @@ def launch(orig_args: List[str]) -> None:
                 else:
                     machete_client.print_annotation(branch)
         elif cmd == "delete-unmanaged":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             machete_client.delete_unmanaged(opt_yes=cli_opts.opt_yes)
         elif cmd in {"diff", alias_by_command["diff"]}:
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             machete_client.diff(branch=parsed_cli.branch, opt_stat=cli_opts.opt_stat)  # passing None if not specified
         elif cmd == "discover":
             # No need to read definition file.
@@ -576,7 +577,7 @@ def launch(orig_args: List[str]) -> None:
             # No need to read definition file.
             print(os.path.abspath(machete_client.definition_file_path))
         elif cmd == "fork-point":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             if cli_opts.opt_inferred:
                 print(machete_client.fork_point(
@@ -606,7 +607,7 @@ def launch(orig_args: List[str]) -> None:
                     use_overrides=True,
                     opt_no_detect_squash_merges=cli_opts.opt_no_detect_squash_merges))
         elif cmd in {"go", alias_by_command["go"]}:
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             dest = machete_client.parse_direction(
@@ -646,7 +647,7 @@ def launch(orig_args: List[str]) -> None:
                 machete_client.expect_in_managed_branches(current_branch)
                 machete_client.retarget_github_pr(current_branch)
         elif cmd == "is-managed":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             if branch is None or branch not in machete_client.managed_branches:
                 exit_script(1)
@@ -659,7 +660,7 @@ def launch(orig_args: List[str]) -> None:
                 raise MacheteException(
                     f"`git machete list {category}` does not expect extra arguments")
 
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             res = []
             if category == "addable":
                 def strip_remote_name(remote_branch: RemoteBranchShortName) -> LocalBranchShortName:
@@ -690,7 +691,7 @@ def launch(orig_args: List[str]) -> None:
             if res:
                 print("\n".join(res))
         elif cmd in {"log", alias_by_command["log"]}:
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             machete_client.log(branch)
         elif cmd == "reapply":
@@ -726,7 +727,7 @@ def launch(orig_args: List[str]) -> None:
                     ))
                 )
         elif cmd == "slide-out":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             branches = parsed_cli_as_dict.get('branches', [git.get_current_branch()])
             machete_client.slide_out(
@@ -736,7 +737,7 @@ def launch(orig_args: List[str]) -> None:
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase,
                 opt_no_edit_merge=cli_opts.opt_no_edit_merge)
         elif cmd == "squash":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             if "fork_point" in parsed_cli:
@@ -749,7 +750,7 @@ def launch(orig_args: List[str]) -> None:
                     use_overrides=True,
                     opt_no_detect_squash_merges=cli_opts.opt_no_detect_squash_merges))
         elif cmd in {"status", alias_by_command["status"]}:
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             machete_client.expect_at_least_one_managed_branch()
             machete_client.status(
                 warn_on_yellow_edges=True,
@@ -765,7 +766,7 @@ def launch(orig_args: List[str]) -> None:
                 raise MacheteException(
                     "Invalid argument for `--return-to`. "
                     "Valid arguments: `here|nearest-remaining|stay`.")
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             machete_client.traverse(
                 opt_fetch=cli_opts.opt_fetch,
@@ -780,7 +781,7 @@ def launch(orig_args: List[str]) -> None:
                 opt_start_from=cli_opts.opt_start_from,
                 opt_yes=cli_opts.opt_yes)
         elif cmd == "update":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             if "fork_point" in parsed_cli:
                 machete_client.check_that_forkpoint_is_ancestor_or_equal_to_tip_of_branch(

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -616,7 +616,7 @@ def launch(orig_args: List[str]) -> None:
                 git.checkout(dest)
         elif cmd == "github":
             github_subcommand = parsed_cli.subcommand
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
 
             if 'draft' in parsed_cli and github_subcommand != 'create-pr':
                 raise MacheteException("'--draft' option is only valid with 'create-pr' subcommand.")
@@ -695,7 +695,7 @@ def launch(orig_args: List[str]) -> None:
             branch = get_branch_arg_or_current_branch(cli_opts, git)
             machete_client.log(branch)
         elif cmd == "reapply":
-            machete_client.read_definition_file()
+            machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd))
             git.expect_no_operation_in_progress()
             current_branch = git.get_current_branch()
             if "fork_point" in parsed_cli:
@@ -717,7 +717,8 @@ def launch(orig_args: List[str]) -> None:
                         '`show current` with a <branch> argument does not make sense')
                 print(branch)
             else:
-                machete_client.read_definition_file(verify_branches=False)
+                machete_client.read_definition_file(perform_interactive_slide_out=perform_interactive_slide_out(cmd),
+                                                    verify_branches=False)
                 print(
                     '\n'.join(machete_client.parse_direction(
                         direction,

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -158,6 +158,8 @@ class MacheteClient:
                     "Slide them out from the definition file?" + get_pretty_choices("y", "e[dit]", "N"),
                     opt_yes_msg=None, opt_yes=False)
         else:
+            if len(invalid_branches) > 0:
+                print(f"Warning: sliding invalid branches: {', '.join(invalid_branches)} out of the definition file", file=sys.stderr)
             ans = 'y'
 
         def recursive_slide_out_invalid_branches(branch_: LocalBranchShortName) -> List[LocalBranchShortName]:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -82,13 +82,12 @@ class MacheteClient:
             f"machete discover` or `git machete edit`, or edit"
             f" {self._definition_file_path} manually.")
 
-    def read_definition_file(self, verify_branches: bool = True, cmd: str = None) -> None:
+    def read_definition_file(self, perform_interactive_slide_out: bool, verify_branches: bool = True) -> None:
         with open(self._definition_file_path) as file:
             lines: List[str] = [line.rstrip() for line in file.readlines()]
 
         at_depth = {}
         last_depth = -1
-        high_lvl_cmds = {'traverse', 'status', 'discover'}
         hint = "Edit the definition file manually with `git machete edit`"
 
         invalid_branches: List[LocalBranchShortName] = []
@@ -145,7 +144,7 @@ class MacheteClient:
         if not invalid_branches:
             return
 
-        if cmd in high_lvl_cmds:
+        if perform_interactive_slide_out:
             if len(invalid_branches) == 1:
                 ans: str = self.ask_if(
                     f"Skipping `{invalid_branches[0]}` " +
@@ -158,6 +157,8 @@ class MacheteClient:
                     " which are not local branches (perhaps they have been deleted?).\n"
                     "Slide them out from the definition file?" + get_pretty_choices("y", "e[dit]", "N"),
                     opt_yes_msg=None, opt_yes=False)
+        else:
+            ans = 'y'
 
         def recursive_slide_out_invalid_branches(branch_: LocalBranchShortName) -> List[LocalBranchShortName]:
             new_down_branches = flat_map(

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -82,13 +82,13 @@ class MacheteClient:
             f"machete discover` or `git machete edit`, or edit"
             f" {self._definition_file_path} manually.")
 
-    def read_definition_file(self, verify_branches: bool = True) -> None:
+    def read_definition_file(self, verify_branches: bool = True, cmd: str = None) -> None:
         with open(self._definition_file_path) as file:
             lines: List[str] = [line.rstrip() for line in file.readlines()]
 
         at_depth = {}
         last_depth = -1
-
+        high_lvl_cmds = {'traverse', 'status', 'discover'}
         hint = "Edit the definition file manually with `git machete edit`"
 
         invalid_branches: List[LocalBranchShortName] = []
@@ -145,18 +145,19 @@ class MacheteClient:
         if not invalid_branches:
             return
 
-        if len(invalid_branches) == 1:
-            ans: str = self.ask_if(
-                f"Skipping `{invalid_branches[0]}` " +
-                "which is not a local branch (perhaps it has been deleted?).\n" +
-                "Slide it out from the definition file?" +
-                get_pretty_choices("y", "e[dit]", "N"), opt_yes_msg=None, opt_yes=False)
-        else:
-            ans = self.ask_if(
-                f"Skipping {', '.join(f'`{branch}`' for branch in invalid_branches)}"
-                " which are not local branches (perhaps they have been deleted?).\n"
-                "Slide them out from the definition file?" + get_pretty_choices("y", "e[dit]", "N"),
-                opt_yes_msg=None, opt_yes=False)
+        if cmd in high_lvl_cmds:
+            if len(invalid_branches) == 1:
+                ans: str = self.ask_if(
+                    f"Skipping `{invalid_branches[0]}` " +
+                    "which is not a local branch (perhaps it has been deleted?).\n" +
+                    "Slide it out from the definition file?" +
+                    get_pretty_choices("y", "e[dit]", "N"), opt_yes_msg=None, opt_yes=False)
+            else:
+                ans = self.ask_if(
+                    f"Skipping {', '.join(f'`{branch}`' for branch in invalid_branches)}"
+                    " which are not local branches (perhaps they have been deleted?).\n"
+                    "Slide them out from the definition file?" + get_pretty_choices("y", "e[dit]", "N"),
+                    opt_yes_msg=None, opt_yes=False)
 
         def recursive_slide_out_invalid_branches(branch_: LocalBranchShortName) -> List[LocalBranchShortName]:
             new_down_branches = flat_map(

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -257,3 +257,8 @@ def slurp_file_or_empty(path: str) -> str:
             return file.read()
     except IOError:
         return ''
+
+
+def perform_interactive_slide_out(cmd: str) -> bool:
+    high_level_commands = {'traverse', 'status'}
+    return sys.stdout.isatty() and cmd in high_level_commands

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -260,5 +260,5 @@ def slurp_file_or_empty(path: str) -> str:
 
 
 def perform_interactive_slide_out(cmd: str) -> bool:
-    high_level_commands = {'traverse', 'status'}
-    return sys.stdout.isatty() and cmd in high_level_commands
+    interactive_slide_out_safe_commands = {'traverse', 'status'}
+    return sys.stdout.isatty() and cmd in interactive_slide_out_safe_commands


### PR DESCRIPTION
closes #443 

### Commands that read definition file:
- add
- advance
- anno
- delete-unmanaged
- diff
- fork-point
- go
- github
- is-managed
- list
- log
- reaply
- show
- slide-out
- squash
- status (high-lvl?)
- traverse (high-lvl?)
- update