### PR TITLE
Issue #432: Do not print stack trace when handling `KeyboardInterrupt` exception

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -794,10 +794,12 @@ def launch(orig_args: List[str]) -> None:
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase,
                 opt_fork_point=cli_opts.opt_fork_point)
 
+    except KeyboardInterrupt:
+        exit_script(3)
     except (argparse.ArgumentError, argparse.ArgumentTypeError) as e:
         print(get_short_general_usage())
         exit_script(2, e)
-    except (MacheteException, KeyboardInterrupt) as e:
+    except MacheteException as e:
         exit_script(1, e)
     except StopInteraction:
         pass


### PR DESCRIPTION
closes #432 