### PR TITLE
Issue #468: Display a more verbose message when GITHUB_TOKEN env variable is missing 

### DIFF
--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1855,7 +1855,6 @@ class MacheteClient:
             msg = ("Could not determine current user name, please check that the GitHub API token provided by one of the: "
                    f"{get_github_token_possible_providers()}is valid.")
             if fail_on_missing_current_user_for_my_opened_prs:
-                raise MacheteException(msg)
                 warn(msg)
                 return
             else:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1855,6 +1855,7 @@ class MacheteClient:
             msg = ("Could not determine current user name, please check that the GitHub API token provided by one of the: "
                    f"{get_github_token_possible_providers()}is valid.")
             if fail_on_missing_current_user_for_my_opened_prs:
+                raise MacheteException(msg)
                 warn(msg)
                 return
             else:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1852,12 +1852,12 @@ class MacheteClient:
         remote, (org, repo) = self.__derive_remote_and_github_org_and_repo()
         current_user: Optional[str] = git_machete.github.derive_current_user_login()
         if not current_user and my_opened_prs:
+            msg = f"Could not determine current user name, please check your {GITHUB_TOKEN_ENV_VAR} environment variable."
             if fail_on_missing_current_user_for_my_opened_prs:
-                # TODO (#468): Display a more verbose message when GITHUB_TOKEN env variable is missing
-                warn("Could not determine current user name, please check your token.")
+                warn(msg)
                 return
             else:
-                raise MacheteException("Could not determine current user name, please check your token.")
+                raise MacheteException(msg)
         all_open_prs: List[GitHubPullRequest] = derive_pull_requests(org, repo)
         applicable_prs: List[GitHubPullRequest] = self.__get_applicable_pull_requests(pr_nos,
                                                                                       all_opened_prs_from_github=all_open_prs,

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -17,7 +17,7 @@ from git_machete.git_operations import (
     AnyBranchName, AnyRevision, ForkPointOverrideData,
     FullCommitHash, GitContext, GitLogEntry, HEAD, BranchPair, LocalBranchShortName, RemoteBranchShortName)
 from git_machete.github import (
-    add_assignees_to_pull_request, add_reviewers_to_pull_request,
+    GITHUB_TOKEN_ENV_VAR, add_assignees_to_pull_request, add_reviewers_to_pull_request,
     create_pull_request, checkout_pr_refs, derive_pull_request_by_head, derive_pull_requests,
     get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest,
     is_github_remote_url, set_base_of_pull_request, set_milestone_of_pull_request)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -17,9 +17,9 @@ from git_machete.git_operations import (
     AnyBranchName, AnyRevision, ForkPointOverrideData,
     FullCommitHash, GitContext, GitLogEntry, HEAD, BranchPair, LocalBranchShortName, RemoteBranchShortName)
 from git_machete.github import (
-    GITHUB_TOKEN_ENV_VAR, add_assignees_to_pull_request, add_reviewers_to_pull_request,
+    add_assignees_to_pull_request, add_reviewers_to_pull_request,
     create_pull_request, checkout_pr_refs, derive_pull_request_by_head, derive_pull_requests,
-    get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest,
+    get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest, GITHUB_TOKEN_ENV_VAR,
     is_github_remote_url, set_base_of_pull_request, set_milestone_of_pull_request)
 from git_machete.utils import (
     get_pretty_choices, flat_map, excluding, fmt, tupled, warn, debug, bold,

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -19,7 +19,7 @@ from git_machete.git_operations import (
 from git_machete.github import (
     add_assignees_to_pull_request, add_reviewers_to_pull_request,
     create_pull_request, checkout_pr_refs, derive_pull_request_by_head, derive_pull_requests,
-    get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest, GITHUB_TOKEN_ENV_VAR,
+    get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest, get_github_token_access_possibilities,
     is_github_remote_url, set_base_of_pull_request, set_milestone_of_pull_request)
 from git_machete.utils import (
     get_pretty_choices, flat_map, excluding, fmt, tupled, warn, debug, bold,
@@ -1852,7 +1852,8 @@ class MacheteClient:
         remote, (org, repo) = self.__derive_remote_and_github_org_and_repo()
         current_user: Optional[str] = git_machete.github.derive_current_user_login()
         if not current_user and my_opened_prs:
-            msg = f"Could not determine current user name, please check your {GITHUB_TOKEN_ENV_VAR} environment variable."
+            msg = ("Could not determine current user name, please check that the GitHub API token provided by one of the: "
+                   f"{get_github_token_access_possibilities()}is valid.")
             if fail_on_missing_current_user_for_my_opened_prs:
                 warn(msg)
                 return

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -19,7 +19,7 @@ from git_machete.git_operations import (
 from git_machete.github import (
     add_assignees_to_pull_request, add_reviewers_to_pull_request,
     create_pull_request, checkout_pr_refs, derive_pull_request_by_head, derive_pull_requests,
-    get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest, get_github_token_access_possibilities,
+    get_github_token_possible_providers, get_parsed_github_remote_url, get_pull_request_by_number_or_none, GitHubPullRequest,
     is_github_remote_url, set_base_of_pull_request, set_milestone_of_pull_request)
 from git_machete.utils import (
     get_pretty_choices, flat_map, excluding, fmt, tupled, warn, debug, bold,
@@ -1853,7 +1853,7 @@ class MacheteClient:
         current_user: Optional[str] = git_machete.github.derive_current_user_login()
         if not current_user and my_opened_prs:
             msg = ("Could not determine current user name, please check that the GitHub API token provided by one of the: "
-                   f"{get_github_token_access_possibilities()}is valid.")
+                   f"{get_github_token_possible_providers()}is valid.")
             if fail_on_missing_current_user_for_my_opened_prs:
                 warn(msg)
                 return

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -166,12 +166,12 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
             first_line = f'GitHub API returned {err.code} HTTP status with error message: `{err.reason}`\n'
             if token:
                 raise MacheteException(first_line + f'Make sure that the GitHub API token provided by one of the: '
-                                                    f'{get_github_token_access_possibilities()}is valid and allows for access to '
+                                                    f'{get_github_token_possible_providers()}is valid and allows for access to '
                                                     f'`{method.upper()}` https://{host}{path}`.')
             else:
                 raise MacheteException(
                     first_line + f'You might not have the required permissions for this repository. '
-                                 f'Provide a GitHub API token with `repo` access via one of the: {get_github_token_access_possibilities()}'
+                                 f'Provide a GitHub API token with `repo` access via one of the: {get_github_token_possible_providers()}'
                                  'Visit `https://github.com/settings/tokens` to generate a new one.')
         elif err.code == http.HTTPStatus.NOT_FOUND:
             raise MacheteException(
@@ -277,7 +277,7 @@ def checkout_pr_refs(git: GitContext, remote: str, pr_number: int, branch: Local
     git.checkout(branch)
 
 
-def get_github_token_access_possibilities() -> str:
+def get_github_token_possible_providers() -> str:
     return (f'\n\t1. `{GITHUB_TOKEN_ENV_VAR}` environment variable.\n'
             '\t2. Content of the `~/.github-token` file.\n'
             '\t3. Current auth token from the `gh` GitHub CLI.\n'

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -167,7 +167,7 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
             if token:
                 raise MacheteException(first_line + f'Make sure that the GitHub API token provided by one of the: '
                                                     f'{get_github_token_possible_providers()}is valid and allows for access to '
-                                                    f'`{method.upper()}` https://{host}{path}`.')
+                                                    f'`{method.upper()}` `https://{host}{path}`.')
             else:
                 raise MacheteException(
                     first_line + f'You might not have the required permissions for this repository. '

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -165,12 +165,13 @@ def __fire_github_api_request(method: str, path: str, token: Optional[str], requ
         elif err.code in (http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN):
             first_line = f'GitHub API returned {err.code} HTTP status with error message: `{err.reason}`\n'
             if token:
-                raise MacheteException(first_line + f'Make sure that the token provided in `gh auth status` or `~/.config/hub`'
-                                                    f' or <b>{GITHUB_TOKEN_ENV_VAR}</b> is valid and allows for access to `{method.upper()}` https://{host}{path}`.')
+                raise MacheteException(first_line + f'Make sure that the GitHub API token provided by one of the: '
+                                                    f'{get_github_token_access_possibilities()}is valid and allows for access to '
+                                                    f'`{method.upper()}` https://{host}{path}`.')
             else:
                 raise MacheteException(
                     first_line + f'You might not have the required permissions for this repository. '
-                                 f'Provide a GitHub API token with `repo` access via <b>{GITHUB_TOKEN_ENV_VAR}</b> env var or `gh` or `hub`.\n'
+                                 f'Provide a GitHub API token with `repo` access via one of the: {get_github_token_access_possibilities()}'
                                  'Visit `https://github.com/settings/tokens` to generate a new one.')
         elif err.code == http.HTTPStatus.NOT_FOUND:
             raise MacheteException(
@@ -274,3 +275,10 @@ def get_pull_request_by_number_or_none(number: int, org: str, repo: str) -> Opti
 def checkout_pr_refs(git: GitContext, remote: str, pr_number: int, branch: LocalBranchShortName) -> None:
     git.fetch_ref(remote, f'pull/{pr_number}/head:{branch}')
     git.checkout(branch)
+
+
+def get_github_token_access_possibilities() -> str:
+    return (f'\n\t1. `{GITHUB_TOKEN_ENV_VAR}` environment variable.\n'
+            '\t2. Content of the `~/.github-token` file.\n'
+            '\t3. Current auth token from the `gh` GitHub CLI.\n'
+            '\t4. Current auth token from the `hub` GitHub CLI.\n')


### PR DESCRIPTION
closes #468 