### PR TITLE
Issue #474: When using `git machete github checkout-prs --by=...` switch current head branch only when one PR is checked out

### DIFF
--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -25,7 +25,7 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
   Check out the head branch of the given pull requests (specified by number),
   also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
   Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
-  If only one PR is given, then switch the local repository's HEAD to its head branch.
+  If only one PR has been checked out, then switch the local repository's HEAD to its head branch.
 
   **Options:**
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -546,7 +546,9 @@ def launch(orig_args: List[str]) -> None:
                 branch=branch,
                 opt_onto=cli_opts.opt_onto,
                 opt_as_root=cli_opts.opt_as_root,
-                opt_yes=cli_opts.opt_yes)
+                opt_yes=cli_opts.opt_yes,
+                verbose=True,
+                switch_head_if_new_branch=True)
         elif cmd == "advance":
             machete_client.read_definition_file(perform_interactive_slide_out=should_perform_interactive_slide_out)
             git.expect_no_operation_in_progress()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -220,7 +220,7 @@ class MacheteClient:
             opt_as_root: bool,
             opt_yes: bool,
             verbose: bool = True,
-            switch_branch: bool = True
+            switch_head_if_new_branch: bool = True
             ) -> None:
         if branch in self.managed_branches:
             raise MacheteException(
@@ -238,7 +238,7 @@ class MacheteClient:
                 msg = common_line + f"Check out `{branch}` locally?" + get_pretty_choices('y', 'N')
                 opt_yes_msg = common_line + f"Checking out `{branch}` locally..."
                 if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                    self.__git.create_branch(branch, remote_branch.full_name(), switch_branch=switch_branch)
+                    self.__git.create_branch(branch, remote_branch.full_name(), switch_head=switch_head_if_new_branch)
                 else:
                     return
                 # Not dealing with `onto` here. If it hasn't been explicitly
@@ -257,7 +257,7 @@ class MacheteClient:
                         current_branch = self.__git.get_current_branch_or_none()
                         if current_branch and current_branch in self.managed_branches:
                             opt_onto = current_branch
-                    self.__git.create_branch(branch, out_of, switch_branch=switch_branch)
+                    self.__git.create_branch(branch, out_of, switch_head=switch_head_if_new_branch)
                 else:
                     return
 
@@ -1915,7 +1915,7 @@ class MacheteClient:
                             opt_onto=None,
                             opt_yes=True,
                             verbose=verbose,
-                            switch_branch=False)
+                            switch_head_if_new_branch=False)
                     else:
                         self.add(
                             branch=branch,
@@ -1923,7 +1923,7 @@ class MacheteClient:
                             opt_as_root=False,
                             opt_yes=True,
                             verbose=verbose,
-                            switch_branch=False)
+                            switch_head_if_new_branch=False)
                     if pr not in checked_out_prs:
                         print(fmt(f"Pull request `#{pr.number}` checked out at local branch `{pr.head}`"))
                         checked_out_prs.append(pr)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -219,7 +219,8 @@ class MacheteClient:
             opt_onto: Optional[LocalBranchShortName],
             opt_as_root: bool,
             opt_yes: bool,
-            verbose: bool = True
+            verbose: bool = True,
+            switch_branch: bool = True
             ) -> None:
         if branch in self.managed_branches:
             raise MacheteException(
@@ -237,7 +238,7 @@ class MacheteClient:
                 msg = common_line + f"Check out `{branch}` locally?" + get_pretty_choices('y', 'N')
                 opt_yes_msg = common_line + f"Checking out `{branch}` locally..."
                 if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                    self.__git.create_branch(branch, remote_branch.full_name())
+                    self.__git.create_branch(branch, remote_branch.full_name(), switch_branch=switch_branch)
                 else:
                     return
                 # Not dealing with `onto` here. If it hasn't been explicitly
@@ -256,7 +257,7 @@ class MacheteClient:
                         current_branch = self.__git.get_current_branch_or_none()
                         if current_branch and current_branch in self.managed_branches:
                             opt_onto = current_branch
-                    self.__git.create_branch(branch, out_of)
+                    self.__git.create_branch(branch, out_of, switch_branch=switch_branch)
                 else:
                     return
 
@@ -1913,14 +1914,16 @@ class MacheteClient:
                             opt_as_root=True,
                             opt_onto=None,
                             opt_yes=True,
-                            verbose=verbose)
+                            verbose=verbose,
+                            switch_branch=False)
                     else:
                         self.add(
                             branch=branch,
                             opt_onto=reversed_path[index - 1],
                             opt_as_root=False,
                             opt_yes=True,
-                            verbose=verbose)
+                            verbose=verbose,
+                            switch_branch=False)
                     if pr not in checked_out_prs:
                         print(fmt(f"Pull request `#{pr.number}` checked out at local branch `{pr.head}`"))
                         checked_out_prs.append(pr)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1930,7 +1930,7 @@ class MacheteClient:
 
         debug('Current GitHub user is ' + (current_user or '<none>'))
         self.__sync_annotations_to_definition_file(all_open_prs, current_user, verbose=verbose)
-        if pr and len(applicable_prs) == 1 and len(checked_out_prs) == 1:
+        if pr and len(checked_out_prs) == 1:
             self.__git.checkout(LocalBranchShortName.of(pr.head))
             if verbose:
                 print(fmt(f"Switched to local branch `{pr.head}`"))

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -219,8 +219,8 @@ class MacheteClient:
             opt_onto: Optional[LocalBranchShortName],
             opt_as_root: bool,
             opt_yes: bool,
-            verbose: bool = True,
-            switch_head_if_new_branch: bool = True
+            verbose: bool,
+            switch_head_if_new_branch: bool
             ) -> None:
         if branch in self.managed_branches:
             raise MacheteException(
@@ -2269,7 +2269,12 @@ class MacheteClient:
 
         current_branch = self.__git.get_current_branch()
         if current_branch not in self.managed_branches:
-            self.add(branch=current_branch, opt_onto=opt_onto, opt_as_root=False, opt_yes=opt_yes)
+            self.add(branch=current_branch,
+                     opt_onto=opt_onto,
+                     opt_as_root=False,
+                     opt_yes=opt_yes,
+                     verbose=True,
+                     switch_head_if_new_branch=True)
             if current_branch not in self.managed_branches:
                 raise MacheteException(
                     "Command `github create-pr` can NOT be executed on the branch"

--- a/git_machete/docs.py
+++ b/git_machete/docs.py
@@ -351,7 +351,7 @@ long_docs: Dict[str, str] = {
           Check out the head branch of the given pull requests (specified by number),
           also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
           Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
-          If only one PR is given, then switch the local repository's HEAD to its head branch.
+          If only one PR has been checked out, then switch the local repository's HEAD to its head branch.
 
           <b>Options:</b>
             <b>--all</b>     Checkout all open PRs.

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -580,9 +580,9 @@ class GitContext:
                                                          ))
             return self.__reflogs_cached[branch]
 
-    def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision, switch_branch: bool) -> None:
+    def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision, switch_head: bool) -> None:
         self._run_git("branch", branch, out_of_revision)
-        if switch_branch:
+        if switch_head:
             self._run_git("checkout", branch)
         self.flush_caches()  # the repository state has changed because of a successful branch creation, let's defensively flush all the caches
 

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -583,7 +583,7 @@ class GitContext:
     def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision, switch_branch: bool) -> None:
         self._run_git("branch", branch, out_of_revision)
         if switch_branch:
-            self._run_git("switch", branch)
+            self._run_git("checkout", branch)
         self.flush_caches()  # the repository state has changed because of a successful branch creation, let's defensively flush all the caches
 
     def flush_caches(self) -> None:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -580,8 +580,10 @@ class GitContext:
                                                          ))
             return self.__reflogs_cached[branch]
 
-    def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision) -> None:
+    def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision, switch_branch: bool) -> None:
         self._run_git("branch", branch, out_of_revision)
+        if switch_branch:
+            self._run_git("switch", branch)
         self.flush_caches()  # the repository state has changed because of a successful branch creation, let's defensively flush all the caches
 
     def flush_caches(self) -> None:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -581,7 +581,7 @@ class GitContext:
             return self.__reflogs_cached[branch]
 
     def create_branch(self, branch: LocalBranchShortName, out_of_revision: AnyRevision) -> None:
-        self._run_git("checkout", "-b", branch, out_of_revision)
+        self._run_git("branch", branch, out_of_revision)
         self.flush_caches()  # the repository state has changed because of a successful branch creation, let's defensively flush all the caches
 
     def flush_caches(self) -> None:

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -50,7 +50,7 @@ def mock_exit_script(status_code: Optional[int] = None, error: Optional[BaseExce
 
 def mock_fetch_ref(cls: Any, remote: str, ref: str) -> None:
     branch: LocalBranchShortName = LocalBranchShortName.of(ref[ref.index(':') + 1:])
-    git.create_branch(branch, get_current_commit_hash())
+    git.create_branch(branch, get_current_commit_hash(), switch_branch=False)
     git.checkout(branch)
 
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -50,8 +50,7 @@ def mock_exit_script(status_code: Optional[int] = None, error: Optional[BaseExce
 
 def mock_fetch_ref(cls: Any, remote: str, ref: str) -> None:
     branch: LocalBranchShortName = LocalBranchShortName.of(ref[ref.index(':') + 1:])
-    git.create_branch(branch, get_current_commit_hash(), switch_head=False)
-    git.checkout(branch)
+    git.create_branch(branch, get_current_commit_hash(), switch_head=True)
 
 
 def mock_run_cmd(cmd: str, *args: str, **kwargs: Any) -> int:

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -50,7 +50,7 @@ def mock_exit_script(status_code: Optional[int] = None, error: Optional[BaseExce
 
 def mock_fetch_ref(cls: Any, remote: str, ref: str) -> None:
     branch: LocalBranchShortName = LocalBranchShortName.of(ref[ref.index(':') + 1:])
-    git.create_branch(branch, get_current_commit_hash(), switch_branch=True)
+    git.create_branch(branch, get_current_commit_hash(), switch_branch=False)
     git.checkout(branch)
 
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -50,7 +50,7 @@ def mock_exit_script(status_code: Optional[int] = None, error: Optional[BaseExce
 
 def mock_fetch_ref(cls: Any, remote: str, ref: str) -> None:
     branch: LocalBranchShortName = LocalBranchShortName.of(ref[ref.index(':') + 1:])
-    git.create_branch(branch, get_current_commit_hash(), switch_branch=False)
+    git.create_branch(branch, get_current_commit_hash(), switch_branch=True)
     git.checkout(branch)
 
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -2404,13 +2404,13 @@ class MacheteTester(unittest.TestCase):
             |       |
             |       o-chore/redundant_checks  PR #18 (github_user)
             |
-            o-enhance/add_user *  PR #19 (github_user)
+            o-enhance/add_user  PR #19 (github_user)
 
             bugfix/add_user
             |
             o-testing/add_user  PR #22 (github_user)
               |
-              o-chore/comments  PR #24 (github_user)
+              o-chore/comments *  PR #24 (github_user)
             """
         )
 

--- a/git_machete/tests/functional/test_machete.py
+++ b/git_machete/tests/functional/test_machete.py
@@ -50,7 +50,7 @@ def mock_exit_script(status_code: Optional[int] = None, error: Optional[BaseExce
 
 def mock_fetch_ref(cls: Any, remote: str, ref: str) -> None:
     branch: LocalBranchShortName = LocalBranchShortName.of(ref[ref.index(':') + 1:])
-    git.create_branch(branch, get_current_commit_hash(), switch_branch=False)
+    git.create_branch(branch, get_current_commit_hash(), switch_head=False)
     git.checkout(branch)
 
 


### PR DESCRIPTION
closes #474
closes #437