### PR TITLE
Issue #478: `git machete github checkout-prs` accepts again --verbose or --debug options

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -644,6 +644,7 @@ def launch(orig_args: List[str]) -> None:
             if github_subcommand == "anno-prs":
                 machete_client.sync_annotations_to_github_prs()
             elif github_subcommand == "checkout-prs":
+
                 if len(parsed_cli_as_dict) > 3 or len(parsed_cli_as_dict) == 2:
                     raise MacheteException(
                         f"'checkout-prs' subcommand can take only one of following options: {', '.join(['--all', '--by', '--mine', 'pr-no'])}")

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -644,10 +644,9 @@ def launch(orig_args: List[str]) -> None:
             if github_subcommand == "anno-prs":
                 machete_client.sync_annotations_to_github_prs()
             elif github_subcommand == "checkout-prs":
-
-                if len(parsed_cli_as_dict) > 3 or len(parsed_cli_as_dict) == 2:
+                if len(set(parsed_cli_as_dict.keys()).intersection({'all', 'by', 'mine', 'pr_no'})) != 1:
                     raise MacheteException(
-                        f"'checkout-prs' subcommand can take only one of following options: {', '.join(['--all', '--by', '--mine', 'pr-no'])}")
+                        f"'checkout-prs' subcommand must take only one of the following options: {', '.join(['--all', '--by', '--mine', 'pr-no'])}")
                 machete_client.checkout_github_prs(pr_nos=parsed_cli.pr_no if 'pr_no' in parsed_cli else [],
                                                    all_opened_prs=parsed_cli.all if 'all' in parsed_cli else False,
                                                    my_opened_prs=parsed_cli.mine if 'mine' in parsed_cli else False,


### PR DESCRIPTION
closes #478

I checked and `--verbose` and `--debug` did not work only for `git machete github checkout-prs`.