### PR TITLE
Fix fork point being incorrectly inferred when parent branch has been pushed immediately after being created

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.11.4
 
 - fixed: git-machete crashing when a local branch uses another local branch as its remote tracking branch (`git config branch.BRANCH.remote` set to `.`)
+- fixed: fork point incorrectly inferred when a branch has been pushed immediately after being created
 
 ## New in git-machete 3.11.3
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1395,8 +1395,11 @@ class MacheteClient:
                            # The rare case of a no-op rebase, the exact wording
                            # likely depends on git version
                            gs_ == f"rebase finished: {branch.full_name()} onto {hash_}" or
-                           gs_ == f"rebase -i (finish): {branch.full_name()} onto {hash_}"
-                           )
+                           gs_ == f"rebase -i (finish): {branch.full_name()} onto {hash_}" or
+                           # For remote branches, let's NOT include the pushes,
+                           # as a branch can be pushed directly after being created,
+                           # which might lead to fork point being inferred too *late* in the history
+                           gs_ == "update by push")
             if is_excluded:
                 debug("skipping reflog entry")
             return is_excluded

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -282,3 +282,28 @@ class TestStatus:
             """
         )
         assert_command(['status'], expected_status_output)
+
+    def test_status_when_child_branch_is_pushed_immediately_after_creation(self, mocker: Any) -> None:
+        mocker.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
+
+        (
+            self.repo_sandbox.new_branch("master")
+            .commit("master")
+            .push()
+            .new_branch("foo")
+            .commit("foo")
+            .new_branch("bar")
+            .push()
+            .commit("bar")
+        )
+        launch_command('discover', '-y')
+        expected_status_output = (
+            """
+            master
+            |
+            o-foo (untracked)
+              |
+              o-bar * (ahead of origin)
+            """
+        )
+        assert_command(['status'], expected_status_output)


### PR DESCRIPTION
Another fix inspired by @wbar ;D tests to be added