### PR TITLE
docs(readme): Use core instead of VirtusLab tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ git-machete requires Python >= 3.6. Python 2.x is no longer supported.
 ### Using Homebrew (macOS)
 
 ```shell script
-brew tap VirtusLab/git-machete
 brew install git-machete
 ```
 


### PR DESCRIPTION
Installing from the VirtusLab tap threw a deprecation warning for me just now:

```shell
$ brew install VirtusLab/git-machete/git-machete
==> Tapping virtuslab/git-machete
Cloning into '/opt/homebrew/Library/Taps/virtuslab/homebrew-git-machete'...
…
Warning: Use git-machete instead of deprecated VirtusLab/git-machete/git-machete
```