### PR TITLE
Remove redundant information about  `--push-untracked` being a default option for `traverse`

### DIFF
--- a/docs/source/cli_help/traverse.rst
+++ b/docs/source/cli_help/traverse.rst
@@ -88,7 +88,7 @@ Unlike with e.g. ``git rebase``, there is no special ``--continue`` flag, as ``t
                              by setting git configuration key ``git config machete.traverse.push false``.
                              Configuration key value can be overridden by the presence of the flag.
 
---push-untracked             Push untracked branches to remote --- default behavior.
+--push-untracked             Push untracked branches to remote.
 
 --return-to=WHERE            Specifies the branch to return after traversal is successfully completed;
                              WHERE can be ``here`` (the current branch at the moment when traversal starts), ``nearest-remaining``

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -989,7 +989,7 @@ long_docs: Dict[str, str] = {
               by setting git configuration key `git config machete.traverse.push false`.
               Configuration key value can be overridden by the presence of the flag.
            <b>--push-untracked</b>
-              Push untracked branches to remote — default behavior.
+              Push untracked branches to remote.
            <b>--return-to=WHERE</b>
               Specifies the branch to return after traversal is successfully completed;
               WHERE can be `here` (the current branch at the moment when traversal starts), `nearest-remaining`


### PR DESCRIPTION
Doc for `--push` option already says that pushing untracked branches is a default option ->
```
--push                       
Push all (both tracked and untracked) branches to remote --- default behavior. Default behaviour can be changed
by setting git configuration key ``git config machete.traverse.push false``.
Configuration key value can be overridden by the presence of the flag.
```