### PR TITLE
Issue #293: A way to mark branches that should not be rebased and/or pushed during `traverse`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.14.0
 
+- added: `push=no` and `rebase=no` branch qualifiers that control push and rebase behaviour of `git machete traverse`
+
 ## New in git-machete 3.13.2
 
 - fixed: redo the failed release

--- a/docs/source/cli_help/anno.rst
+++ b/docs/source/cli_help/anno.rst
@@ -21,13 +21,17 @@ If invoked with a single empty string <annotation text>, like:
 then clears the annotation for the current branch (or a branch specified with ``-b/--branch``).
 
 If invoked with ``-H`` or ``--sync-github-prs``, annotates the branches based on their corresponding GitHub PR numbers and authors.
-Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
+When the current user is **not** the owner of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+so that you don't rebase or push someone else's PR by accident (see help for :ref:`traverse`).
+Any existing annotations (except branch qualifiers) are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
 
 .. include:: github_api_access.rst
 .. include:: github_config_keys.rst
 
 In any other case, sets the annotation for the given/current branch to the given <annotation text>.
 If multiple <annotation text>'s are passed to the command, they are concatenated with a single space.
+
+Note: ``anno`` command is able to overwrite existing branch qualifiers.
 
 Note: all the effects of ``anno`` can be always achieved by manually editing the definition file.
 

--- a/docs/source/cli_help/discover.rst
+++ b/docs/source/cli_help/discover.rst
@@ -13,6 +13,7 @@ Discovers and displays tree of branch dependencies using a heuristic based on re
 If confirmed with a ``y[es]`` or ``e[dit]`` reply, backs up the current definition file (if it exists) as ``$GIT_DIR/machete~``
 and saves the new tree under the usual ``$GIT_DIR/machete`` path.
 If the reply was ``e[dit]``, additionally an editor is opened (as in: ``git machete`` :ref:`edit`) after saving the new definition file.
+``discover`` retains the existing branch qualifiers used by ``git machete traverse`` (see help for :ref:`traverse`).
 
 **Options:**
 

--- a/docs/source/cli_help/format.rst
+++ b/docs/source/cli_help/format.rst
@@ -9,12 +9,12 @@ The format of the definition file should be as follows:
 .. code-block::
 
     develop
-        adjust-reads-prec PR #234
-            block-cancel-order PR #235
+        adjust-reads-prec PR #234 rebase=no push=no
+            block-cancel-order PR #235 rebase=no
                 change-table
                     drop-location-type
         edit-margin-not-allowed
-            full-load-gatling
+            full-load-gatling push=no
         grep-errors-script
     master
         hotfix/receipt-trigger PR #236
@@ -23,8 +23,8 @@ In the above example ``develop`` and ``master`` are roots of the tree of branch 
 Branches ``adjust-reads-prec``, ``edit-margin-not-allowed`` and ``grep-errors-script`` are direct downstream branches for ``develop``.
 ``block-cancel-order`` is a downstream branch of ``adjust-reads-prec``, ``change-table`` is a downstream branch of ``block-cancel-order`` and so on.
 
-Every branch name can be followed (after a single space as a delimiter) by a custom annotation --- a PR number in the above example.
-The annotations don't influence the way ``git machete`` operates other than that they are displayed in the output of the ``status`` command.
+Every branch name can be followed (after a single space as a delimiter) by a custom annotation, e.g. ``PR #234 rebase=no push=no``, ``PR #235 rebase=no`` or ``push=no``.
+Annotations might contain underlined branch qualifiers (``rebase=no``, ``push=no``) that control rebase and push behaviour of ``traverse`` (see help for :ref:`traverse`).
 Also see help for :ref:`anno` command.
 
 Tabs or any number of spaces can be used as indentation.

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -21,6 +21,8 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
     Annotates the branches based on their corresponding GitHub PR numbers and authors.
     Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
     Equivalent to ``git machete anno --sync-github-prs``.
+    When the current user is **not** the owner of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    so that you don't rebase or push someone else's PR by accident (see help for :ref:`traverse`).
 
 
 ``checkout-prs [--all | --by=<github-login> | --mine | <PR-number-1> ... <PR-number-N>]``:
@@ -28,6 +30,8 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
     also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
     Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
     If only one PR has been checked out, then switch the local repository's HEAD to its head branch.
+    When the current user is **not** the owner of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    so that you don't rebase or push someone else's PR by accident (see help for :ref:`traverse`).
 
     **Options:**
 

--- a/docs/source/cli_help/status.rst
+++ b/docs/source/cli_help/status.rst
@@ -41,7 +41,8 @@ Apart from simply ASCII-formatting the definition file, this also:
     * prints (``untracked``/``ahead of <remote>``/``behind <remote>``/``diverged from [& older than] <remote>``) message if the branch
       is not in sync with its remote counterpart;
 
-    * displays the custom annotations (see help for :ref:`format` and :ref:`anno`) next to each branch, if present;
+    * displays the custom annotations (see help for :ref:`format` and :ref:`anno`) next to each branch, if present. Annotations might contain underlined branch
+      qualifiers (``rebase=no``, ``push=no``) that control rebase and push behaviour of ``traverse`` (see help for :ref:`traverse`);
 
     * displays the output of ``machete-status-branch hook`` (see help for :ref:`hooks`), if present;
 

--- a/docs/source/cli_help/traverse.rst
+++ b/docs/source/cli_help/traverse.rst
@@ -65,6 +65,24 @@ It will pick up the walk from the current branch (unless ``--start-from=`` or ``
 Unlike with e.g. ``git rebase``, there is no special ``--continue`` flag, as ``traverse`` is stateless
 (doesn't keep a state of its own like ``git rebase`` does in ``.git/rebase-apply/``).
 
+The rebase and push behaviour of ``traverse`` can also be customized for each branch separately using *branch qualifiers*.
+There are ``rebase=no`` and ``push=no`` qualifiers that can be used to opt out of default behaviour (rebasing and pushing).
+The qualifier can appear anywhere in the annotation but needs to be separated by a whitespace from any other character, e.g. ``some_annotation_text rebase=no push=no``.
+Qualifiers can only be overwritten by manually editing ``.git/machete`` file or modifying it with ``git machete e[dit]`` or by updating annotations with ``git machete anno``.
+Example machete file with branch qualifiers:
+
+.. code-block::
+
+    master
+      develop  rebase=no
+        my-branch  PR #123
+        someone-elses-branch  PR #124 rebase=no push=no
+        branch-for-local-experiments  push=no
+
+Operations like ``git machete github anno-prs`` and ``git machete github checkout-prs`` add ``rebase=no push=no`` branch qualifiers
+when the current user is **not** the owner of the PR associated with that branch. ``git machete discover`` doesn't modify the qualifiers.
+
+
 **Options:**
 
 -F, --fetch                  Fetch the remotes of all managed branches at the beginning of traversal (no ``git pull`` involved, only ``git fetch``).

--- a/git_machete/annotation.py
+++ b/git_machete/annotation.py
@@ -1,0 +1,58 @@
+import re
+from typing import Callable
+
+from git_machete import utils
+
+
+class Qualifiers:
+    rebase: bool
+    push: bool
+
+    def __init__(self, annotation: str):
+        self._annotation = annotation
+        self._annotation_without_qualifiers = annotation
+        self._rebase_text = ''
+        self._push_text = ''
+        self.rebase = True
+        self.push = True
+
+        match_pattern: Callable[[str], str] = lambda text: f'.*\\b{text}=no\\b.*'
+        sub_pattern: Callable[[str], str] = lambda text: f'[ ]?{text}=no[ ]?'
+
+        rebase_match = re.match(match_pattern('rebase'), annotation)
+        if rebase_match:
+            self.rebase = False
+            self._rebase_text = 'rebase=no'
+            self._annotation_without_qualifiers = re.sub(sub_pattern('rebase'), ' ', self._annotation_without_qualifiers)
+
+        push_match = re.match(match_pattern('push'), annotation)
+        if push_match:
+            self.push = False
+            self._push_text = 'push=no'
+            self._annotation_without_qualifiers = re.sub(sub_pattern('push'), ' ', self._annotation_without_qualifiers)
+
+    def get_annotation_text_without_qualifiers(self) -> str:
+        return self._annotation_without_qualifiers.strip()
+
+    def get_qualifiers_text(self) -> str:
+        return f'{self._rebase_text.strip()} {self._push_text.strip()}'.replace('  ', ' ').strip()
+
+
+class Annotation:
+    text: str
+    text_without_qualifiers: str
+    qualifiers_text: str
+    qualifiers: Qualifiers
+
+    def __init__(self, text: str):
+        self.text = text
+        self.qualifiers = Qualifiers(text)
+        self.text_without_qualifiers = self.qualifiers.get_annotation_text_without_qualifiers()
+        self.qualifiers_text = self.qualifiers.get_qualifiers_text()
+
+    def get_formatted_text(self) -> str:
+        annotation_text = f"  {utils.dim(self.text_without_qualifiers)}"
+        if self.qualifiers_text != '':
+            annotation_text += ' ' if self.text_without_qualifiers != '' else ''
+            annotation_text += utils.dim(utils.underline(s=self.qualifiers_text))
+        return annotation_text

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -536,21 +536,20 @@ def launch(orig_args: List[str]) -> None:
 
         machete_client = MacheteClient(git)
 
-        if cmd != 'discover':
-            if not os.path.exists(machete_client.definition_file_path):
-                # We're opening in "append" and not "write" mode to avoid a race condition:
-                # if other process writes to the file between we check the
-                # result of `os.path.exists` and call `open`,
-                # then open(..., "w") would result in us clearing up the file
-                # contents, while open(..., "a") has no effect.
-                with open(machete_client.definition_file_path, "a"):
-                    pass
-            elif os.path.isdir(machete_client.definition_file_path):
-                # Extremely unlikely case, basically checking if anybody
-                # tampered with the repository.
-                raise MacheteException(
-                    f"{machete_client.definition_file_path} is a directory "
-                    "rather than a regular file, aborting")
+        if not os.path.exists(machete_client.definition_file_path):
+            # We're opening in "append" and not "write" mode to avoid a race condition:
+            # if other process writes to the file between we check the
+            # result of `os.path.exists` and call `open`,
+            # then open(..., "w") would result in us clearing up the file
+            # contents, while open(..., "a") has no effect.
+            with open(machete_client.definition_file_path, "a"):
+                pass
+        elif os.path.isdir(machete_client.definition_file_path):
+            # Extremely unlikely case, basically checking if anybody
+            # tampered with the repository.
+            raise MacheteException(
+                f"{machete_client.definition_file_path} is a directory "
+                "rather than a regular file, aborting")
 
         should_perform_interactive_slide_out = MacheteClient.should_perform_interactive_slide_out(cmd)
         if cmd == "add":
@@ -596,7 +595,7 @@ def launch(orig_args: List[str]) -> None:
             machete_client.diff(branch=get_local_branch_short_name_from_arg(cli_opts.opt_branch),
                                 opt_stat=cli_opts.opt_stat)  # passing None if not specified
         elif cmd == "discover":
-            # No need to read definition file.
+            machete_client.read_definition_file(perform_interactive_slide_out=should_perform_interactive_slide_out)
             machete_client.discover_tree(
                 opt_checked_out_since=cli_opts.opt_checked_out_since,
                 opt_list_commits=cli_opts.opt_list_commits,

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -354,7 +354,7 @@ def launch_command(*args: str) -> str:
 def assert_command(cmds: Iterable[str], expected_result: str, strip_indentation: bool = True, indent: str = '  ') -> None:
     expected_result = adapt(expected_result, indent) if strip_indentation else expected_result
     actual_result = launch_command(*cmds)
-    assert actual_result == expected_result, f'Actual result:\n`{actual_result}`\nExpected result: `{expected_result}`'
+    assert actual_result == expected_result, f'Actual result:\n`{actual_result}`\nExpected result:\n`{expected_result}`'
 
 
 def rewrite_definition_file(new_body: str) -> None:

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -69,3 +69,27 @@ class TestAnno:
             x-feature  Custom annotation for `feature` branch (untracked)
             """,
         )
+
+        # check if annotation qualifiers are parsed correctly and that they can be overwritten by `git machete anno`
+        launch_command('anno', '-b=refs/heads/feature', 'push=no Custom annotation for `feature` branch rebase=no')
+        assert_command(
+            ["status"],
+            """
+            master (untracked)
+
+            develop *  Custom annotation for `develop` branch (untracked)
+            |
+            x-feature  Custom annotation for `feature` branch rebase=no push=no (untracked)
+            """,
+        )
+        launch_command('anno', '-b=refs/heads/feature', 'Custom annotation for `feature` branch')
+        assert_command(
+            ["status"],
+            """
+            master (untracked)
+
+            develop *  Custom annotation for `develop` branch (untracked)
+            |
+            x-feature  Custom annotation for `feature` branch (untracked)
+            """,
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,127 @@
+from textwrap import dedent
+from typing import Dict
+
+from git_machete.client import MacheteClient
+from git_machete.git_operations import GitContext, LocalBranchShortName
+from git_machete.annotation import Annotation
+from .mockers import (GitRepositorySandbox, rewrite_definition_file)
+
+
+class TestClient:
+
+    def setup_method(self) -> None:
+
+        self.repo_sandbox = GitRepositorySandbox()
+
+        (
+            self.repo_sandbox
+            # Create the remote and sandbox repos, chdir into sandbox repo
+            .new_repo(self.repo_sandbox.remote_path, "--bare")
+            .new_repo(self.repo_sandbox.local_path)
+            .execute(f"git remote add origin {self.repo_sandbox.remote_path}")
+            .execute('git config user.email "tester@test.com"')
+            .execute('git config user.name "Tester Test"')
+        )
+
+    def test_annotations_read_definition_file(self) -> None:
+        """
+        Verify behaviour of a 'MacheteClient.read_definition_file()' method
+        """
+        (
+            self.repo_sandbox
+                .new_branch('master')
+                .commit()
+                .push()
+                .new_branch('feature1')
+                .commit()
+                .new_branch('feature2')
+                .commit()
+                .check_out("master")
+                .new_branch('feature3')
+                .commit()
+                .push()
+                .new_branch('feature4')
+                .commit()
+                .check_out("master")
+                .new_branch('feature5')
+                .commit()
+                .check_out("master")
+                .new_branch('feature6')
+                .commit()
+                .check_out("master")
+                .new_branch('feature7')
+                .commit()
+                .check_out("master")
+                .new_branch('feature8')
+                .commit()
+        )
+
+        body: str = \
+            """
+            master
+            feature1
+            feature2 annotation
+            feature3 annotation rebase=no push=no
+            feature4 rebase=no push=no annotation
+            feature5 annotation1 rebase=no annotation2 push=no annotation3
+            feature6 annotation1 rebase=nopush=no annotation2
+            feature7 annotation1rebase=no push=noannotation2
+            feature8 annotation rebase=no push=no rebase=no push=no
+            """
+        body = dedent(body)
+
+        self.repo_sandbox.new_branch("root")
+        rewrite_definition_file(body)
+        git = GitContext()
+        machete_client = MacheteClient(git)
+        machete_client.read_definition_file(perform_interactive_slide_out=False)
+        annotations: Dict[LocalBranchShortName, Annotation] = machete_client.annotations
+
+        feature_2_branch = LocalBranchShortName.of('feature2')
+        assert annotations[feature_2_branch].text == 'annotation'
+        assert annotations[feature_2_branch].qualifiers.rebase is True
+        assert annotations[feature_2_branch].qualifiers.push is True
+        assert annotations[feature_2_branch].text_without_qualifiers == 'annotation'
+        assert annotations[feature_2_branch].qualifiers_text == ''
+
+        feature_3_branch = LocalBranchShortName.of('feature3')
+        assert annotations[feature_3_branch].text == 'annotation rebase=no push=no'
+        assert annotations[feature_3_branch].qualifiers.rebase is False
+        assert annotations[feature_3_branch].qualifiers.push is False
+        assert annotations[feature_3_branch].text_without_qualifiers == 'annotation'
+        assert annotations[feature_3_branch].qualifiers_text == 'rebase=no push=no'
+
+        feature_4_branch = LocalBranchShortName.of('feature4')
+        assert annotations[feature_4_branch].text == 'rebase=no push=no annotation'
+        assert annotations[feature_4_branch].qualifiers.rebase is False
+        assert annotations[feature_4_branch].qualifiers.push is False
+        assert annotations[feature_4_branch].text_without_qualifiers == 'annotation'
+        assert annotations[feature_4_branch].qualifiers_text == 'rebase=no push=no'
+
+        feature_5_branch = LocalBranchShortName.of('feature5')
+        assert annotations[feature_5_branch].text == 'annotation1 rebase=no annotation2 push=no annotation3'
+        assert annotations[feature_5_branch].qualifiers.rebase is False
+        assert annotations[feature_5_branch].qualifiers.push is False
+        assert annotations[feature_5_branch].text_without_qualifiers == 'annotation1 annotation2 annotation3'
+        assert annotations[feature_5_branch].qualifiers_text == 'rebase=no push=no'
+
+        feature_6_branch = LocalBranchShortName.of('feature6')
+        assert annotations[feature_6_branch].text == 'annotation1 rebase=nopush=no annotation2'
+        assert annotations[feature_6_branch].qualifiers.rebase is True
+        assert annotations[feature_6_branch].qualifiers.push is True
+        assert annotations[feature_6_branch].text_without_qualifiers == 'annotation1 rebase=nopush=no annotation2'
+        assert annotations[feature_6_branch].qualifiers_text == ''
+
+        feature_7_branch = LocalBranchShortName.of('feature7')
+        assert annotations[feature_7_branch].text == 'annotation1rebase=no push=noannotation2'
+        assert annotations[feature_7_branch].qualifiers.rebase is True
+        assert annotations[feature_7_branch].qualifiers.push is True
+        assert annotations[feature_7_branch].text_without_qualifiers == 'annotation1rebase=no push=noannotation2'
+        assert annotations[feature_7_branch].qualifiers_text == ''
+
+        feature_8_branch = LocalBranchShortName.of('feature8')
+        assert annotations[feature_8_branch].text == 'annotation rebase=no push=no rebase=no push=no'
+        assert annotations[feature_8_branch].qualifiers.rebase is False
+        assert annotations[feature_8_branch].qualifiers.push is False
+        assert annotations[feature_8_branch].text_without_qualifiers == 'annotation'
+        assert annotations[feature_8_branch].qualifiers_text == 'rebase=no push=no'

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,62 @@
+from textwrap import dedent
+from .mockers import (assert_command, GitRepositorySandbox, launch_command, rewrite_definition_file)
+
+
+class TestDiscover:
+
+    def setup_method(self) -> None:
+        self.repo_sandbox = GitRepositorySandbox()
+
+        (
+            self.repo_sandbox
+            # Create the remote and sandbox repos, chdir into sandbox repo
+            .new_repo(self.repo_sandbox.remote_path, "--bare")
+            .new_repo(self.repo_sandbox.local_path)
+            .execute(f"git remote add origin {self.repo_sandbox.remote_path}")
+            .execute('git config user.email "tester@test.com"')
+            .execute('git config user.name "Tester Test"')
+        )
+
+    def test_discover(self) -> None:
+        (
+            self.repo_sandbox
+                .new_branch('master')
+                .commit()
+                .push()
+                .new_branch('feature1')
+                .commit()
+                .new_branch('feature2')
+                .commit()
+                .check_out("master")
+                .new_branch('feature3')
+                .commit()
+                .push()
+                .new_branch('feature4')
+                .commit()
+        )
+
+        body: str = \
+            """
+            master
+            feature1
+            feature2 annotation
+            feature3 annotation rebase=no push=no
+            """
+        body = dedent(body)
+
+        rewrite_definition_file(body)
+        launch_command('discover', '-y')
+        expected_status_output = (
+            """
+            master
+            |
+            o-feature1 (untracked)
+            | |
+            | o-feature2 (untracked)
+            |
+            o-feature3  rebase=no push=no
+              |
+              o-feature4 * (untracked)
+            """
+        )
+        assert_command(['status'], expected_status_output)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -125,7 +125,7 @@ class TestGithub:
         |
         o-branch-1
           |
-          o-feature *  PR #15 (github_user) WRONG PR BASE or MACHETE PARENT? PR has 'root'
+          o-feature *  PR #15 (github_user) WRONG PR BASE or MACHETE PARENT? PR has 'root' rebase=no push=no
         """
         assert_command(
             ['status'],
@@ -278,7 +278,7 @@ class TestGithub:
             },
             {
                 'head': {'ref': 'call-ws', 'repo': mock_repository_info},
-                'user': {'login': 'github_user'},
+                'user': {'login': 'very_complex_user_token'},
                 'base': {'ref': 'develop'},
                 'number': '31',
                 'html_url': 'www.github.com',
@@ -333,6 +333,11 @@ class TestGithub:
                 .add_remote('new_origin', 'https://github.com/user/repo.git')
         )
         launch_command("discover", "-y")
+
+        # test that `anno-prs` add `rebase=no push=no` qualifiers to branches associated with the PRs whose owner
+        # is different than the current user, overwrite annotation text but doesn't overwrite existing qualifiers
+        launch_command('anno', '-b=allow-ownership-link', 'rebase=no')
+        launch_command('anno', '-b=build-chain', 'rebase=no push=no')
         launch_command('github', 'anno-prs')
         assert_command(
             ["status"],
@@ -341,15 +346,15 @@ class TestGithub:
             |
             o-hotfix/add-trigger (diverged from origin)
               |
-              o-ignore-trailing *  PR #3 (github_user) (diverged from & older than origin)
+              o-ignore-trailing *  PR #3 (github_user) rebase=no push=no (diverged from & older than origin)
 
             develop
             |
-            x-allow-ownership-link  PR #7 (github_user) (ahead of origin)
+            x-allow-ownership-link  PR #7 (github_user) rebase=no (ahead of origin)
             | |
-            | x-build-chain (untracked)
+            | x-build-chain  rebase=no push=no (untracked)
             |
-            o-call-ws  PR #31 (github_user) (ahead of origin)
+            o-call-ws  PR #31 (ahead of origin)
               |
               x-drop-constraint (untracked)
             """
@@ -373,15 +378,15 @@ class TestGithub:
             |
             o-hotfix/add-trigger (diverged from origin)
               |
-              o-ignore-trailing *  PR #3 (github_user) (diverged from & older than origin)
+              o-ignore-trailing *  PR #3 (github_user) rebase=no push=no (diverged from & older than origin)
 
             develop
             |
-            x-allow-ownership-link  PR #7 (github_user) (ahead of origin)
+            x-allow-ownership-link  PR #7 (github_user) rebase=no (ahead of origin)
             | |
-            | x-build-chain (untracked)
+            | x-build-chain  rebase=no push=no (untracked)
             |
-            o-call-ws  PR #31 (github_user) (ahead of origin)
+            o-call-ws  PR #31 (ahead of origin)
               |
               x-drop-constraint (untracked)
             """,
@@ -979,7 +984,7 @@ class TestGithub:
             |
             o-hotfix/add-trigger
               |
-              o-ignore-trailing  PR #3 (github_user)
+              o-ignore-trailing  PR #3 (github_user) rebase=no push=no
                 |
                 o-chore/fields
 
@@ -987,13 +992,13 @@ class TestGithub:
             |
             o-enhance/feature
               |
-              o-bugfix/feature  PR #6 (github_user)
+              o-bugfix/feature  PR #6 (github_user) rebase=no push=no
                 |
-                o-allow-ownership-link  PR #12 (github_user)
+                o-allow-ownership-link  PR #12 (github_user) rebase=no push=no
                   |
-                  o-restrict_access  PR #17 (github_user)
+                  o-restrict_access  PR #17 (github_user) rebase=no push=no
                     |
-                    o-chore/redundant_checks *  PR #18 (github_user)
+                    o-chore/redundant_checks *  PR #18 (github_user) rebase=no push=no
             """
         )
         # broken chain of pull requests (add new root)
@@ -1005,7 +1010,7 @@ class TestGithub:
             |
             o-hotfix/add-trigger
               |
-              o-ignore-trailing  PR #3 (github_user)
+              o-ignore-trailing  PR #3 (github_user) rebase=no push=no
                 |
                 o-chore/fields
 
@@ -1013,19 +1018,19 @@ class TestGithub:
             |
             o-enhance/feature
               |
-              o-bugfix/feature  PR #6 (github_user)
+              o-bugfix/feature  PR #6 (github_user) rebase=no push=no
                 |
-                o-allow-ownership-link  PR #12 (github_user)
+                o-allow-ownership-link  PR #12 (github_user) rebase=no push=no
                   |
-                  o-restrict_access  PR #17 (github_user)
+                  o-restrict_access  PR #17 (github_user) rebase=no push=no
                     |
-                    o-chore/redundant_checks  PR #18 (github_user)
+                    o-chore/redundant_checks  PR #18 (github_user) rebase=no push=no
 
             bugfix/add_user
             |
-            o-testing/add_user  PR #22 (github_user)
+            o-testing/add_user  PR #22 (github_user) rebase=no push=no
               |
-              o-chore/comments *  PR #24 (github_user)
+              o-chore/comments *  PR #24 (github_user) rebase=no push=no
             """
         )
 
@@ -1038,7 +1043,7 @@ class TestGithub:
             |
             o-hotfix/add-trigger
               |
-              o-ignore-trailing  PR #3 (github_user)
+              o-ignore-trailing  PR #3 (github_user) rebase=no push=no
                 |
                 o-chore/fields
 
@@ -1046,19 +1051,19 @@ class TestGithub:
             |
             o-enhance/feature
               |
-              o-bugfix/feature  PR #6 (github_user)
+              o-bugfix/feature  PR #6 (github_user) rebase=no push=no
                 |
-                o-allow-ownership-link  PR #12 (github_user)
+                o-allow-ownership-link  PR #12 (github_user) rebase=no push=no
                   |
-                  o-restrict_access  PR #17 (github_user)
+                  o-restrict_access  PR #17 (github_user) rebase=no push=no
                     |
-                    o-chore/redundant_checks  PR #18 (github_user)
+                    o-chore/redundant_checks  PR #18 (github_user) rebase=no push=no
 
             bugfix/add_user
             |
-            o-testing/add_user  PR #22 (github_user)
+            o-testing/add_user  PR #22 (github_user) rebase=no push=no
               |
-              o-chore/comments *  PR #24 (github_user)
+              o-chore/comments *  PR #24 (github_user) rebase=no push=no
             """
         )
 
@@ -1071,7 +1076,7 @@ class TestGithub:
             |
             o-hotfix/add-trigger
               |
-              o-ignore-trailing  PR #3 (github_user)
+              o-ignore-trailing  PR #3 (github_user) rebase=no push=no
                 |
                 o-chore/fields
 
@@ -1079,21 +1084,21 @@ class TestGithub:
             |
             o-enhance/feature
             | |
-            | o-bugfix/feature  PR #6 (github_user)
+            | o-bugfix/feature  PR #6 (github_user) rebase=no push=no
             |   |
-            |   o-allow-ownership-link  PR #12 (github_user)
+            |   o-allow-ownership-link  PR #12 (github_user) rebase=no push=no
             |     |
-            |     o-restrict_access  PR #17 (github_user)
+            |     o-restrict_access  PR #17 (github_user) rebase=no push=no
             |       |
-            |       o-chore/redundant_checks  PR #18 (github_user)
+            |       o-chore/redundant_checks  PR #18 (github_user) rebase=no push=no
             |
-            o-enhance/add_user  PR #19 (github_user)
+            o-enhance/add_user  PR #19 (github_user) rebase=no push=no
 
             bugfix/add_user
             |
-            o-testing/add_user  PR #22 (github_user)
+            o-testing/add_user  PR #22 (github_user) rebase=no push=no
               |
-              o-chore/comments *  PR #24 (github_user)
+              o-chore/comments *  PR #24 (github_user) rebase=no push=no
             """
         )
 
@@ -1270,9 +1275,9 @@ class TestGithub:
 
             chore/sync_to_docs
             |
-            o-improve/refactor  PR #1 (github_user)
+            o-improve/refactor  PR #1 (github_user) rebase=no push=no
               |
-              o-comments/add_docstrings *  PR #2 (github_user)
+              o-comments/add_docstrings *  PR #2 (github_user) rebase=no push=no
             """
         )
 
@@ -1294,9 +1299,9 @@ class TestGithub:
 
             chore/sync_to_docs
             |
-            o-improve/refactor  PR #1 (github_user)
+            o-improve/refactor  PR #1 (github_user) rebase=no push=no
               |
-              o-comments/add_docstrings  PR #2 (github_user)
+              o-comments/add_docstrings  PR #2 (github_user) rebase=no push=no
                 |
                 o-sphinx_export *
             """
@@ -1356,6 +1361,222 @@ class TestGithub:
             ("Verify that 'git machete github checkout prs' performs 'git checkout' to "
              "the head branch of given pull request."
              )
+
+    git_api_state_for_test_github_checkout_prs_of_current_user_and_other_users = MockGitHubAPIState(
+        [
+            {
+                'head': {'ref': 'chore/redundant_checks', 'repo': mock_repository_info},
+                'user': {'login': 'github_user'},
+                'base': {'ref': 'restrict_access'},
+                'number': '18',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'restrict_access', 'repo': mock_repository_info},
+                'user': {'login': 'very_complex_user_token'},
+                'base': {'ref': 'allow-ownership-link'},
+                'number': '17',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'allow-ownership-link', 'repo': mock_repository_info},
+                'user': {'login': 'github_user'},
+                'base': {'ref': 'bugfix/feature'},
+                'number': '12',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'bugfix/feature', 'repo': mock_repository_info},
+                'user': {'login': 'very_complex_user_token'},
+                'base': {'ref': 'enhance/feature'},
+                'number': '6',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'enhance/add_user', 'repo': mock_repository_info},
+                'user': {'login': 'github_user'},
+                'base': {'ref': 'develop'},
+                'number': '19',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'testing/add_user', 'repo': mock_repository_info},
+                'user': {'login': 'very_complex_user_token'},
+                'base': {'ref': 'bugfix/add_user'},
+                'number': '22',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {'head': {'ref': 'chore/comments', 'repo': mock_repository_info},
+             'user': {'login': 'github_user'},
+             'base': {'ref': 'testing/add_user'},
+             'number': '24',
+             'html_url': 'www.github.com',
+             'state': 'open'
+             },
+            {
+                'head': {'ref': 'ignore-trailing', 'repo': mock_repository_info},
+                'user': {'login': 'very_complex_user_token'},
+                'base': {'ref': 'hotfix/add-trigger'},
+                'number': '3',
+                'html_url': 'www.github.com',
+                'state': 'open'
+            },
+            {
+                'head': {'ref': 'bugfix/remove-n-option',
+                         'repo': {'full_name': 'testing/checkout_prs', 'html_url': GitRepositorySandbox.second_remote_path}},
+                'user': {'login': 'github_user'},
+                'base': {'ref': 'develop'},
+                'number': '5',
+                'html_url': 'www.github.com',
+                'state': 'closed'
+            }
+        ]
+    )
+
+    @mock.patch('git_machete.cli.exit_script', mock_exit_script)
+    # We need to mock GITHUB_REMOTE_PATTERNS in the tests for `test_github_checkout_prs`
+    # due to `git fetch` executed by `checkout-prs` subcommand.
+    @mock.patch('git_machete.github.GITHUB_REMOTE_PATTERNS', FAKE_GITHUB_REMOTE_PATTERNS)
+    @mock.patch('git_machete.options.CommandLineOptions', FakeCommandLineOptions)
+    @mock.patch('git_machete.utils.run_cmd', mock_run_cmd)  # to hide git outputs in tests
+    @mock.patch('git_machete.github.__get_github_token', mock__get_github_token)
+    @mock.patch('urllib.request.Request', git_api_state_for_test_github_checkout_prs_of_current_user_and_other_users.new_request())
+    @mock.patch('urllib.request.urlopen', MockContextManager)
+    @mock.patch('git_machete.github.derive_current_user_login', mock_derive_current_user_login)
+    def test_github_checkout_prs_of_current_user_and_other_users(self, tmp_path: Any) -> None:
+        (
+            self.repo_sandbox.new_branch("root")
+            .commit("initial commit")
+            .new_branch("develop")
+            .commit("first commit")
+            .push()
+            .new_branch("enhance/feature")
+            .commit("introduce feature")
+            .push()
+            .new_branch("bugfix/feature")
+            .commit("bugs removed")
+            .push()
+            .new_branch("allow-ownership-link")
+            .commit("fixes")
+            .push()
+            .new_branch('restrict_access')
+            .commit('authorized users only')
+            .push()
+            .new_branch("chore/redundant_checks")
+            .commit('remove some checks')
+            .push()
+            .check_out("root")
+            .new_branch("master")
+            .commit("Master commit")
+            .push()
+            .new_branch("hotfix/add-trigger")
+            .commit("HOTFIX Add the trigger")
+            .push()
+            .new_branch("ignore-trailing")
+            .commit("Ignore trailing data")
+            .push()
+            .delete_branch("root")
+            .new_branch('chore/fields')
+            .commit("remove outdated fields")
+            .push()
+            .check_out('develop')
+            .new_branch('enhance/add_user')
+            .commit('allow externals to add users')
+            .push()
+            .new_branch('bugfix/add_user')
+            .commit('first round of fixes')
+            .push()
+            .new_branch('testing/add_user')
+            .commit('add test set for add_user feature')
+            .push()
+            .new_branch('chore/comments')
+            .commit('code maintenance')
+            .push()
+            .check_out('master')
+        )
+        for branch in ('chore/redundant_checks', 'restrict_access', 'allow-ownership-link', 'bugfix/feature', 'enhance/add_user',
+                       'testing/add_user', 'chore/comments', 'bugfix/add_user'):
+            self.repo_sandbox.execute(f"git branch -D {branch}")
+
+        launch_command('discover')
+
+        # test that `checkout-prs` add `rebase=no push=no` qualifiers to branches associated with the PRs whose owner
+        # is different than the current user
+        launch_command('github', 'checkout-prs', '--all')
+        assert_command(
+            ["status"],
+            """
+            master *
+            |
+            o-hotfix/add-trigger
+              |
+              o-ignore-trailing  PR #3
+                |
+                o-chore/fields
+
+            develop
+            |
+            o-enhance/feature
+            | |
+            | o-bugfix/feature  PR #6
+            |   |
+            |   o-allow-ownership-link  PR #12 (github_user) rebase=no push=no
+            |     |
+            |     o-restrict_access  PR #17
+            |       |
+            |       o-chore/redundant_checks  PR #18 (github_user) rebase=no push=no
+            |
+            o-enhance/add_user  PR #19 (github_user) rebase=no push=no
+
+            bugfix/add_user
+            |
+            o-testing/add_user  PR #22
+              |
+              o-chore/comments  PR #24 (github_user) rebase=no push=no
+            """
+        )
+
+        # test that `checkout-prs` doesn't overwrite annotation qualifiers but overwrites annotation text
+        launch_command('anno', '-b=allow-ownership-link', 'branch_annotation rebase=no')
+        launch_command('github', 'checkout-prs', '--all')
+        assert_command(
+            ["status"],
+            """
+            master *
+            |
+            o-hotfix/add-trigger
+              |
+              o-ignore-trailing  PR #3
+                |
+                o-chore/fields
+
+            develop
+            |
+            o-enhance/feature
+            | |
+            | o-bugfix/feature  PR #6
+            |   |
+            |   o-allow-ownership-link  PR #12 (github_user) rebase=no
+            |     |
+            |     o-restrict_access  PR #17
+            |       |
+            |       o-chore/redundant_checks  PR #18 (github_user) rebase=no push=no
+            |
+            o-enhance/add_user  PR #19 (github_user) rebase=no push=no
+
+            bugfix/add_user
+            |
+            o-testing/add_user  PR #22
+              |
+              o-chore/comments  PR #24 (github_user) rebase=no push=no
+            """
+        )
 
     git_api_state_for_test_github_sync = MockGitHubAPIState(
         [


### PR DESCRIPTION
TODO:

- [x] Add qualifiers ( rebase/push=no/yes, read-only) that control behaviour of `traverse`
- [x] Add tests
   - [x] `traverse`
   - [x] `discover`
   - [x] `github anno-prs`
   - [x] `github checkout-prs`
- [x] Prevent commands: `discover, github anno-prs, github checkout-prs` (check if there are more commands that can modify annotation) from modifying qualifiers except command `github checkout-prs`
  - [x] `discover`
  - [x] `anno-prs`
  - [x] `checkout-prs`
    -  add `rebase=no push=no` qualifiers for the branch associated with the PR where the owner is different than the current user and there are no qualifiers present for that branch
- [x] update docs
   - [x] `traverse`  
   - [x] `discover`
   - [x] `anno-prs`
   - [x] `checkout-prs`