### PR TITLE
Display branch names in `git-machete` command outputs and prompts with bolded formatting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.15.0
 
-- improved: branch names formatting in `git machete` command prompts and outputs
+- improved: formatting in `git machete` command prompts and outputs
 
 ## New in git-machete 3.14.3
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.15.0
 
+- improved: branch names formatting in `git machete` command prompts and outputs
+
 ## New in git-machete 3.14.3
 
 - improved: docs for `machete.github.*` and other config keys

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -756,7 +756,7 @@ def launch(orig_args: List[str]) -> None:
                 if 'branch' in parsed_cli:
                     raise MacheteException(
                         '`show current` with a <branch> argument does not make sense')
-                print(bold(branch))
+                print(branch)
             else:
                 machete_client.read_definition_file(perform_interactive_slide_out=should_perform_interactive_slide_out,
                                                     verify_branches=False)

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -756,7 +756,7 @@ def launch(orig_args: List[str]) -> None:
                 if 'branch' in parsed_cli:
                     raise MacheteException(
                         '`show current` with a <branch> argument does not make sense')
-                print(branch)
+                print(bold(branch))
             else:
                 machete_client.read_definition_file(perform_interactive_slide_out=should_perform_interactive_slide_out,
                                                     verify_branches=False)

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -630,7 +630,7 @@ def launch(orig_args: List[str]) -> None:
                     machete_client.set_fork_point_override(branch, upstream)
                 else:
                     raise MacheteException(
-                        f"Branch {branch} does not have upstream (parent) branch")
+                        f"Branch {bold(branch)} does not have upstream (parent) branch")
             elif cli_opts.opt_unset_override:
                 machete_client.unset_fork_point_override(branch)
             else:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -342,18 +342,18 @@ class MacheteClient:
         if opt_merge:
             with_branch = self.up(
                 current_branch,
-                prompt_if_inferred_msg=("Branch `%s` not found in the tree of branch dependencies. "
-                                        "Merge with the inferred upstream `%s`?" + get_pretty_choices('y', 'N')),
-                prompt_if_inferred_yes_opt_msg=("Branch `%s` not found in the tree of branch dependencies. "
-                                                "Merging with the inferred upstream `%s`..."))
+                prompt_if_inferred_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
+                                        "Merge with the inferred upstream <b>%s</b>?" + get_pretty_choices('y', 'N')),
+                prompt_if_inferred_yes_opt_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
+                                                "Merging with the inferred upstream <b>%s</b>..."))
             self.__git.merge(with_branch, current_branch, opt_no_edit_merge)
         else:
             onto_branch = self.up(
                 current_branch,
-                prompt_if_inferred_msg=("Branch `%s` not found in the tree of branch dependencies. "
-                                        "Rebase onto the inferred upstream `%s`?" + get_pretty_choices('y', 'N')),
-                prompt_if_inferred_yes_opt_msg=("Branch `%s` not found in the tree of branch dependencies. "
-                                                "Rebasing onto the inferred upstream `%s`..."))
+                prompt_if_inferred_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
+                                        "Rebase onto the inferred upstream <b>%s</b>?" + get_pretty_choices('y', 'N')),
+                prompt_if_inferred_yes_opt_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
+                                                "Rebasing onto the inferred upstream <b>%s</b>..."))
             self.__git.rebase(
                 LocalBranchShortName.of(onto_branch).full_name(),
                 opt_fork_point or self.fork_point(
@@ -1266,7 +1266,7 @@ class MacheteClient:
         self.expect_in_managed_branches(branch)
         dbs = self.__down_branches.get(branch)
         if not dbs:
-            raise MacheteException(f"Branch `{branch}` has no downstream branch")
+            raise MacheteException(f"Branch {bold(branch)} has no downstream branch")
         elif len(dbs) == 1:
             return [dbs[0]]
         elif pick_mode:
@@ -1289,14 +1289,14 @@ class MacheteClient:
         self.expect_in_managed_branches(branch)
         index: int = self.managed_branches.index(branch) + 1
         if index == len(self.managed_branches):
-            raise MacheteException(f"Branch `{branch}` has no successor")
+            raise MacheteException(f"Branch {bold(branch)} has no successor")
         return self.managed_branches[index]
 
     def prev_branch(self, branch: LocalBranchShortName) -> LocalBranchShortName:
         self.expect_in_managed_branches(branch)
         index: int = self.managed_branches.index(branch) - 1
         if index == -1:
-            raise MacheteException(f"Branch `{branch}` has no predecessor")
+            raise MacheteException(f"Branch {bold(branch)} has no predecessor")
         return self.managed_branches[index]
 
     def root_branch(self, branch: LocalBranchShortName, if_unmanaged: int) -> LocalBranchShortName:
@@ -1304,12 +1304,12 @@ class MacheteClient:
             if self.__roots:
                 if if_unmanaged == PICK_FIRST_ROOT:
                     warn(
-                        f"{branch} is not a managed branch, assuming "
+                        f"{bold(branch)} is not a managed branch, assuming "
                         f"{self.__roots[0]} (the first root) instead as root")
                     return self.__roots[0]
                 else:  # if_unmanaged == PICK_LAST_ROOT
                     warn(
-                        f"{branch} is not a managed branch, assuming "
+                        f"{bold(branch)} is not a managed branch, assuming "
                         f"{self.__roots[-1]} (the last root) instead as root")
                     return self.__roots[-1]
             else:
@@ -1327,7 +1327,7 @@ class MacheteClient:
             if upstream:
                 return upstream
             else:
-                raise MacheteException(f"Branch `{branch}` has no upstream branch")
+                raise MacheteException(f"Branch {bold(branch)} has no upstream branch")
         else:
             upstream = self.__infer_upstream(branch)
             if upstream:
@@ -1341,12 +1341,12 @@ class MacheteClient:
                     raise MacheteException("Aborting.")
                 else:
                     warn(
-                        f"branch `{branch}` not found in the tree of branch "
-                        f"dependencies; the upstream has been inferred to `{upstream}`")
+                        f"branch {bold(branch)} not found in the tree of branch "
+                        f"dependencies; the upstream has been inferred to {bold(upstream)}")
                     return upstream
             else:
                 raise MacheteException(
-                    f"Branch `{branch}` not found in the tree of branch "
+                    f"Branch {bold(branch)} not found in the tree of branch "
                     f"dependencies and its upstream could not be inferred")
 
     def get_slidable_branches(self) -> List[LocalBranchShortName]:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -2032,7 +2032,8 @@ class MacheteClient:
                             print(f"Fetching {bold(remote_to_fetch)}...")
                         self.__git.fetch_remote(remote_to_fetch)
                     if '/'.join([remote_to_fetch, pr.head]) not in self.__git.get_remote_branches():
-                        raise MacheteException(f"Could not check out PR {bold('#' + str(pr.number))} because its head branch {bold(pr.head)} "
+                        raise MacheteException(f"Could not check out PR {bold('#' + str(pr.number))} "
+                                               f"because its head branch {bold(pr.head)} "
                                                f"is already deleted from {bold(remote_to_fetch)}.")
             else:
                 warn(f'Pull request {bold("#" + str(pr.number))} comes from fork and its repository is already deleted. '

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1474,7 +1474,7 @@ class MacheteClient:
         _, org, repo = self.__derive_remote_and_github_org_and_repo(domain)
         print('Checking for open GitHub PRs... ', end='', flush=True)
         current_user: Optional[str] = git_machete.github.derive_current_user_login(domain)
-        debug('Current GitHub user is ' + (current_user or '<none>'))
+        debug('Current GitHub user is ' + (bold(current_user) or '<none>'))
         all_open_prs: List[GitHubPullRequest] = derive_pull_requests(domain, org, repo)
         print(fmt('<green><b>OK</b></green>'))
         self.__sync_annotations_to_definition_file(all_open_prs, current_user)
@@ -1487,12 +1487,12 @@ class MacheteClient:
         for pr in prs:
             if LocalBranchShortName.of(pr.head) in self.managed_branches:
                 debug(f'{pr} corresponds to a managed branch')
-                anno: str = f'PR #{pr.number}'
+                anno: str = f'PR {bold("#" + str(pr.number))}'
                 if pr.user != current_user:
-                    anno += f' ({pr.user})'
+                    anno += f' ({bold(pr.user)})'
                 upstream: Optional[LocalBranchShortName] = self.up_branch.get(LocalBranchShortName.of(pr.head))
                 if pr.base != upstream:
-                    warn(f'branch {bold(pr.head)} has a different base in PR #{pr.number} (`{pr.base}`) '
+                    warn(f'branch {bold(pr.head)} has a different base in PR {bold("#" + str(pr.number))} ({bold(pr.base)}) '
                          f'than in machete file ({bold(upstream) or "<none, is a root>"})')
                     anno += f" WRONG PR BASE or MACHETE PARENT? PR has {bold(pr.base)}"
                 old_annotation_text, old_annotation_qualifiers_text = '', ''
@@ -2011,7 +2011,7 @@ class MacheteClient:
 
         debug(f'organization is {org}, repository is {repo}')
         if verbose:
-            print(f"Fetching {remote}...")
+            print(f"Fetching {bold(remote)}...")
         self.__git.fetch_remote(remote)
 
         pr: Optional[GitHubPullRequest] = None
@@ -2029,20 +2029,20 @@ class MacheteClient:
                         remote_to_fetch = remote_already_added
                     if remote != remote_to_fetch:
                         if verbose:
-                            print(f"Fetching {remote_to_fetch}...")
+                            print(f"Fetching {bold(remote_to_fetch)}...")
                         self.__git.fetch_remote(remote_to_fetch)
                     if '/'.join([remote_to_fetch, pr.head]) not in self.__git.get_remote_branches():
-                        raise MacheteException(f"Could not check out PR #{pr.number} because its head branch `{pr.head}` "
-                                               f"is already deleted from `{remote_to_fetch}`.")
+                        raise MacheteException(f"Could not check out PR {bold('#' + str(pr.number))} because its head branch {bold(pr.head)} "
+                                               f"is already deleted from {bold(remote_to_fetch)}.")
             else:
-                warn(f'Pull request #{pr.number} comes from fork and its repository is already deleted. '
-                     f'No remote tracking data will be set up for `{pr.head}` branch.')
+                warn(f'Pull request {bold("#" + str(pr.number))} comes from fork and its repository is already deleted. '
+                     f'No remote tracking data will be set up for {bold(pr.head)} branch.')
                 if verbose:
-                    print(fmt(f"Checking out `{pr.head}` locally..."))
+                    print(fmt(f"Checking out {bold(pr.head)} locally..."))
                 checkout_pr_refs(self.__git, remote, pr.number, LocalBranchShortName.of(pr.head))
                 self.flush_caches()
             if pr.state == 'closed':
-                warn(f'Pull request #{pr.number} is already closed.')
+                warn(f'Pull request {bold("#" + str(pr.number))} is already closed.')
             debug(f'found {pr}')
 
             path: List[LocalBranchShortName] = self.__get_path_from_pr_chain(pr, all_open_prs)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1215,7 +1215,7 @@ class MacheteClient:
                     f"falling back to {upstream} as fork point")
                 return self.__git.get_commit_hash_by_revision(upstream), []
             else:
-                raise MacheteException(f"Cannot find fork point for branch `{branch}`")
+                raise MacheteException(f"Cannot find fork point for branch {bold(branch)}")
         else:
             debug(f"commit {fp_hash} is the most recent point in history of {branch} to occur on "
                   "filtered reflog of any other branch or its remote counterpart "
@@ -1968,8 +1968,8 @@ class MacheteClient:
                 earlier_revision=fork_point_hash.full_name(),
                 later_revision=branch.full_name()):
             raise MacheteException(
-                f"Fork point {fork_point_hash} is not ancestor of or the tip "
-                f"of the {branch} branch.")
+                f"Fork point {bold(fork_point_hash)} is not ancestor of or the tip "
+                f"of the {bold(branch)} branch.")
 
     def checkout_github_prs(self,
                             pr_nos: Optional[List[int]],

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -2481,8 +2481,8 @@ class MacheteClient:
 
         if self.__git.is_ancestor_or_equal(current_branch.full_name(), up_branch.full_name()):
             raise MacheteException(
-                f'All commits in {bold(current_branch)} branch are already included in {bold(up_branch)} branch.'
-                f'\nCannot create pull request.')
+                f'All commits in {bold(current_branch)} branch are already included in {bold(up_branch)} branch.\n'
+                f'Cannot create pull request.')
 
         s, remote = self.__git.get_strict_remote_sync_status(current_branch)
         statuses_to_push = (

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1544,7 +1544,7 @@ class MacheteClient:
                                         ) -> Generator[Tuple[FullCommitHash, List[BranchPair]], None, None]:
 
         if branch not in self.__git.get_local_branches():
-            raise MacheteException(f"`{branch}` is not a local branch")
+            raise MacheteException(f"{bold(branch)} is not a local branch")
 
         if self.__branch_pairs_by_hash_in_reflog is None:
             def generate_entries() -> Generator[Tuple[FullCommitHash, BranchPair], None, None]:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -838,7 +838,7 @@ class MacheteClient:
                         # a subsequent 'git rebase --continue'.
                         rebased_branch = self.__git.get_currently_rebased_branch_or_none()
                         if rebased_branch:  # 'remote_branch' should be equal to 'branch' at this point anyway
-                            print(fmt(f"\nRebase of `{rebased_branch}` in progress; stopping the traversal"))
+                            print(fmt(f"\nRebase of {bold(rebased_branch)} in progress; stopping the traversal"))
                             return
                     if ans == 'yq':
                         return

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1387,7 +1387,7 @@ class MacheteClient:
                 "No commits to squash. Use `-f` or `--fork-point` to specify the "
                 "start of range of commits to squash.")
         if len(commits) == 1:
-            print(f"Exactly one commit ({commits[0].short_hash}) to squash, ignoring.\n")
+            print(f"Exactly one commit ({bold(commits[0].short_hash)}) to squash, ignoring.\n")
             print("Tip: use `-f` or `--fork-point` to specify where the range of "
                   "commits to squash starts.")
             return

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -372,7 +372,7 @@ class MacheteClient:
             raise MacheteException("No local branches found")
         for root in opt_roots:
             if root not in self.__git.get_local_branches():
-                raise MacheteException(f"`{root}` is not a local branch")
+                raise MacheteException(f"{bold(root)} is not a local branch")
         if opt_roots:
             self.__roots = list(map(LocalBranchShortName.of, opt_roots))
         else:
@@ -465,7 +465,7 @@ class MacheteClient:
             warn(
                 "skipping %s since %s merged to another branch and would not "
                 "have any downstream branches.\n"
-                % (", ".join(f"`{branch}`" for branch in merged_branches_to_skip),
+                % (", ".join(f"{bold(branch)}" for branch in merged_branches_to_skip),
                    "it's" if len(merged_branches_to_skip) == 1 else "they're"))
             self.managed_branches = excluding(self.managed_branches, merged_branches_to_skip)
             for branch in merged_branches_to_skip:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1492,9 +1492,9 @@ class MacheteClient:
                     anno += f' ({pr.user})'
                 upstream: Optional[LocalBranchShortName] = self.up_branch.get(LocalBranchShortName.of(pr.head))
                 if pr.base != upstream:
-                    warn(f'branch `{pr.head}` has a different base in PR #{pr.number} (`{pr.base}`) '
-                         f'than in machete file (`{upstream or "<none, is a root>"}`)')
-                    anno += f" WRONG PR BASE or MACHETE PARENT? PR has '{pr.base}'"
+                    warn(f'branch {bold(pr.head)} has a different base in PR #{pr.number} (`{pr.base}`) '
+                         f'than in machete file ({bold(upstream) or "<none, is a root>"})')
+                    anno += f" WRONG PR BASE or MACHETE PARENT? PR has {bold(pr.base)}"
                 old_annotation_text, old_annotation_qualifiers_text = '', ''
                 if LocalBranchShortName.of(pr.head) in self.__annotations:
                     old_annotation_text = self.__annotations[LocalBranchShortName.of(pr.head)].text
@@ -1502,11 +1502,11 @@ class MacheteClient:
 
                 if pr.user != current_user and old_annotation_qualifiers_text == '':
                     if verbose:
-                        print(fmt(f'Annotating `{pr.head}` as `{anno} rebase=no push=no`'))
+                        print(fmt(f'Annotating {bold(pr.head)} as `{anno} rebase=no push=no`'))
                     self.__annotations[LocalBranchShortName.of(pr.head)] = Annotation(f'{anno} rebase=no push=no')
                 elif old_annotation_text != anno:
                     if verbose:
-                        print(fmt(f'Annotating `{pr.head}` as `{anno}`'))
+                        print(fmt(f'Annotating {bold(pr.head)} as `{anno}`'))
                     self.__annotations[LocalBranchShortName.of(pr.head)] = Annotation(f'{anno} {old_annotation_qualifiers_text}') \
                         if old_annotation_text is not None else Annotation(anno)
             else:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -92,7 +92,7 @@ class MacheteClient:
         if branch not in self.managed_branches:
             raise MacheteException(
                 f"Branch {bold(branch)} not found in the tree of branch dependencies.\n"
-                f"Use `git machete add {bold(branch)}` or `git machete edit`")
+                f"Use `git machete add {branch}` or `git machete edit`")
 
     def expect_at_least_one_managed_branch(self) -> None:
         if not self.__roots:
@@ -141,8 +141,8 @@ class MacheteClient:
                     indent_expanded: str = "".join(mapping[c] for c in self.__indent)
                     raise MacheteException(
                         f"{self._definition_file_path}, line {index + 1}: "
-                        f"invalid indent `{prefix_expanded}`, expected a multiply"
-                        f" of `{indent_expanded}`. {hint}")
+                        f"invalid indent {bold(prefix_expanded)}, expected a multiply"
+                        f" of {bold(indent_expanded)}. {hint}")
             else:
                 depth = 0
 
@@ -182,7 +182,8 @@ class MacheteClient:
                     opt_yes_msg=None, opt_yes=False)
         else:
             if len(invalid_branches) > 0:
-                print(f"Warning: sliding invalid branches: {', '.join(invalid_branches)} out of the definition file", file=sys.stderr)
+                print(f"Warning: sliding invalid branches: {', '.join(f'{bold(branch)}' for branch in invalid_branches)} "
+                      f"out of the definition file", file=sys.stderr)
             ans = 'y'
 
         def recursive_slide_out_invalid_branches(branch_: LocalBranchShortName) -> List[LocalBranchShortName]:
@@ -1076,11 +1077,11 @@ class MacheteClient:
                 SyncToRemoteStatuses.NO_REMOTES: "",
                 SyncToRemoteStatuses.UNTRACKED: colored(" (untracked)", AnsiEscapeCodes.ORANGE),
                 SyncToRemoteStatuses.IN_SYNC_WITH_REMOTE: "",
-                SyncToRemoteStatuses.BEHIND_REMOTE: colored(f" (behind {remote})", AnsiEscapeCodes.RED),
-                SyncToRemoteStatuses.AHEAD_OF_REMOTE: colored(f" (ahead of {remote})", AnsiEscapeCodes.RED),
-                SyncToRemoteStatuses.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: colored(f" (diverged from & older than {remote})",
+                SyncToRemoteStatuses.BEHIND_REMOTE: colored(f" (behind {bold(remote)})", AnsiEscapeCodes.RED),
+                SyncToRemoteStatuses.AHEAD_OF_REMOTE: colored(f" (ahead of {bold(remote)})", AnsiEscapeCodes.RED),
+                SyncToRemoteStatuses.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: colored(f" (diverged from & older than {bold(remote)})",
                                                                                   AnsiEscapeCodes.RED),
-                SyncToRemoteStatuses.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: colored(f" (diverged from {remote})", AnsiEscapeCodes.RED)
+                SyncToRemoteStatuses.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: colored(f" (diverged from {bold(remote)})", AnsiEscapeCodes.RED)
             }[SyncToRemoteStatuses(s)]
 
             hook_output = ""
@@ -1104,12 +1105,12 @@ class MacheteClient:
         branches_in_sync_but_fork_point_off = [k for k, v in sync_to_parent_status.items() if v == SyncToParentStatus.InSyncButForkPointOff]
         if branches_in_sync_but_fork_point_off and warn_when_branch_in_sync_but_fork_point_off:
             if len(branches_in_sync_but_fork_point_off) == 1:
-                first_part = f"yellow edge indicates that fork point for `{branches_in_sync_but_fork_point_off[0]}` " \
+                first_part = f"yellow edge indicates that fork point for {bold(branches_in_sync_but_fork_point_off[0])} " \
                              f"is probably incorrectly inferred,\n or that some extra branch should be between " \
-                             f"`{self.up_branch[LocalBranchShortName.of(branches_in_sync_but_fork_point_off[0])]}` and " \
-                             f"`{branches_in_sync_but_fork_point_off[0]}`"
+                             f"{bold(self.up_branch[LocalBranchShortName.of(branches_in_sync_but_fork_point_off[0])])} and " \
+                             f"{bold(branches_in_sync_but_fork_point_off[0])}"
             else:
-                affected_branches = ", ".join(map(lambda x: f"`{x}`", branches_in_sync_but_fork_point_off))
+                affected_branches = ", ".join(map(lambda x: f"{bold(x)}", branches_in_sync_but_fork_point_off))
                 first_part = f"yellow edges indicate that fork points for {affected_branches} are probably incorrectly inferred,\n" \
                              f"or that some extra branch should be added between each of these branches and its parent"
 
@@ -1119,8 +1120,8 @@ class MacheteClient:
             elif len(branches_in_sync_but_fork_point_off) == 1:
                 second_part = "Consider using `git machete fork-point " \
                               f"--override-to=<revision>|--override-to-inferred|--override-to-parent " \
-                              f"{branches_in_sync_but_fork_point_off[0]}`,\nor reattaching `{branches_in_sync_but_fork_point_off[0]}` " \
-                              f"under a different parent branch"
+                              f"{bold(branches_in_sync_but_fork_point_off[0])}`,\nor reattaching " \
+                              f"{bold(branches_in_sync_but_fork_point_off[0])} under a different parent branch"
             else:
                 second_part = "Consider using `git machete fork-point " \
                               "--override-to=<revision>|--override-to-inferred|--override-to-parent <branch>` for each affected branch,\n" \
@@ -2382,7 +2383,7 @@ class MacheteClient:
                 opt_yes=opt_yes)
         else:
             # We know that there is at least 1 remote, otherwise 's' would be 'NO_REMOTES'
-            print(fmt(f"Branch `{bold(branch)}` is untracked and there's no `{bold('origin')}` repository."))
+            print(f"Branch {bold(branch)} is untracked and there's no {bold('origin')} repository.")
             self.__pick_remote(
                 branch=branch,
                 is_called_from_traverse=is_called_from_traverse,

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1700,13 +1700,13 @@ class MacheteClient:
 
     def set_fork_point_override(self, branch: LocalBranchShortName, to_revision: AnyRevision) -> None:
         if branch not in self.__git.get_local_branches():
-            raise MacheteException(f"`{branch}` is not a local branch")
+            raise MacheteException(f"{bold(branch)} is not a local branch")
         to_hash = self.__git.get_commit_hash_by_revision(to_revision)
         if not to_hash:
-            raise MacheteException(f"Cannot find revision {to_revision}")
+            raise MacheteException(f"Cannot find revision {bold(to_revision)}")
         if not self.__git.is_ancestor_or_equal(to_hash.full_name(), branch.full_name()):
             raise MacheteException(
-                f"Cannot override fork point: {self.__git.get_revision_repr(to_revision)} is not an ancestor of {branch}")
+                f"Cannot override fork point: {bold(self.__git.get_revision_repr(to_revision))} is not an ancestor of {bold(branch)}")
 
         to_key = self.config_key_for_override_fork_point_to(branch)
         self.__git.set_config_attr(to_key, to_hash)
@@ -1719,7 +1719,7 @@ class MacheteClient:
                   f"<b>{self.__git.get_revision_repr(to_revision)}</b>.\n",
                   f"This applies as long as {branch} points to (or is descendant of)"
                   " its current head (commit "
-                  f"{self.__git.get_short_commit_hash_by_revision(branch_hash)}).\n\n",
+                  f"<b>{self.__git.get_short_commit_hash_by_revision(branch_hash)}</b>).\n\n",
                   f"This information is stored under git config keys:\n"
                   f"  * `{to_key}`\n"
                   f"  * `{while_descendant_of_key}`\n\n",

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1494,7 +1494,7 @@ class MacheteClient:
                 upstream: Optional[LocalBranchShortName] = self.up_branch.get(LocalBranchShortName.of(pr.head))
                 if pr.base != upstream:
                     warn(f'branch {bold(pr.head)} has a different base in PR #{bold(str(pr.number))} ({bold(pr.base)}) '
-                         f'than in machete file ({bold(upstream) or "<none, is a root>"})')
+                         f'than in machete file ({bold(upstream) if upstream else "<none, is a root>"})')
                     anno += f" WRONG PR BASE or MACHETE PARENT? PR has {bold(pr.base)}"
                 old_annotation_text, old_annotation_qualifiers_text = '', ''
                 if LocalBranchShortName.of(pr.head) in self.__annotations:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -590,7 +590,7 @@ class MacheteClient:
     def advance(self, *, branch: LocalBranchShortName, opt_yes: bool) -> None:
         if not self.__down_branches.get(branch):
             raise MacheteException(
-                f"`{branch}` does not have any downstream (child) branches to advance towards")
+                f"{bold(branch)} does not have any downstream (child) branches to advance towards")
 
         def connected_with_green_edge(bd: LocalBranchShortName) -> bool:
             return bool(
@@ -603,17 +603,17 @@ class MacheteClient:
         candidate_downstreams = list(filter(connected_with_green_edge, self.__down_branches[branch]))
         if not candidate_downstreams:
             raise MacheteException(
-                f"No downstream (child) branch of `{branch}` is connected to "
-                f"`{branch}` with a green edge")
+                f"No downstream (child) branch of {bold(branch)} is connected to "
+                f"{bold(branch)} with a green edge")
         if len(candidate_downstreams) > 1:
             if opt_yes:
                 raise MacheteException(
-                    f"More than one downstream (child) branch of `{branch}` is "
-                    f"connected to `{branch}` with a green edge and `-y/--yes` option is specified")
+                    f"More than one downstream (child) branch of {bold(branch)} is "
+                    f"connected to {bold(branch)} with a green edge and `-y/--yes` option is specified")
             else:
                 down_branch = self.pick(
                     candidate_downstreams,
-                    f"downstream branch towards which `{branch}` is to be fast-forwarded")
+                    f"downstream branch towards which {bold(branch)} is to be fast-forwarded")
                 self.__git.merge_fast_forward_only(down_branch)
         else:
             down_branch = candidate_downstreams[0]

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -515,7 +515,7 @@ class MacheteClient:
             self.expect_in_managed_branches(branch)
             new_upstream = self.up_branch.get(branch)
             if not new_upstream:
-                raise MacheteException(f"No upstream branch defined for `{branch}`, cannot slide out")
+                raise MacheteException(f"No upstream branch defined for {bold(branch)}, cannot slide out")
 
         if opt_down_fork_point:
             last_branch_to_slide_out = branches_to_slide_out[-1]
@@ -535,16 +535,16 @@ class MacheteClient:
         for bu, bd in zip(branches_to_slide_out[:-1], branches_to_slide_out[1:]):
             dbs = self.__down_branches.get(bu)
             if not dbs or len(dbs) == 0:
-                raise MacheteException(f"No downstream branch defined for `{bu}`, cannot slide out")
+                raise MacheteException(f"No downstream branch defined for {bold(bu)}, cannot slide out")
             elif len(dbs) > 1:
-                flat_dbs = ", ".join(f"`{x}`" for x in dbs)
+                flat_dbs = ", ".join(f"{bold(x)}" for x in dbs)
                 raise MacheteException(
-                    f"Multiple downstream branches defined for `{bu}`: {flat_dbs}; cannot slide out")
+                    f"Multiple downstream branches defined for {bold(bu)}: {flat_dbs}; cannot slide out")
             elif dbs != [bd]:
-                raise MacheteException(f"'{bd}' is not downstream of '{bu}', cannot slide out")
+                raise MacheteException(f"{bold(bd)} is not downstream of {bold(bu)}, cannot slide out")
 
             if self.up_branch[bd] != bu:
-                raise MacheteException(f"`{bu}` is not upstream of `{bd}`, cannot slide out")
+                raise MacheteException(f"{bold(bu)} is not upstream of {bold(bd)}, cannot slide out")
 
         # Get new branches
         new_upstream = self.up_branch[branches_to_slide_out[0]]
@@ -1130,7 +1130,7 @@ class MacheteClient:
             warn(f"{first_part}.\n\n{second_part}.")
 
     def delete_unmanaged(self, *, opt_yes: bool) -> None:
-        print(bold('Checking for unmanaged branches...'))
+        print('Checking for unmanaged branches...')
         branches_to_delete = excluding(self.__git.get_local_branches(), self.managed_branches)
         self._delete_branches(branches_to_delete=branches_to_delete, opt_yes=opt_yes)
 
@@ -1138,7 +1138,7 @@ class MacheteClient:
         current_branch = self.__git.get_current_branch_or_none()
         if current_branch and current_branch in branches_to_delete:
             branches_to_delete = excluding(branches_to_delete, [current_branch])
-            print(fmt(f"Skipping current branch {bold(current_branch)}"))
+            print(f"Skipping current branch {bold(current_branch)}")
         if branches_to_delete:
             branches_merged_to_head = self.__git.get_merged_local_branches()
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -128,7 +128,7 @@ class MacheteClient:
             if branch in self.managed_branches:
                 raise MacheteException(
                     f"{self._definition_file_path}, line {index + 1}: branch "
-                    f"`{branch}` re-appears in the tree definition. {hint}")
+                    f"{bold(branch)}` re-appears in the tree definition. {hint}")
             if verify_branches and branch not in self.__git.get_local_branches():
                 invalid_branches += [branch]
             self.managed_branches += [branch]
@@ -150,7 +150,7 @@ class MacheteClient:
                 raise MacheteException(
                     f"{self._definition_file_path}, line {index + 1}: too much "
                     f"indent (level {depth}, expected at most {last_depth + 1}) "
-                    f"for the branch `{branch}`. {hint}")
+                    f"for the branch {bold(branch)}. {hint}")
             last_depth = depth
 
             at_depth[depth] = branch
@@ -170,13 +170,13 @@ class MacheteClient:
         if perform_interactive_slide_out:
             if len(invalid_branches) == 1:
                 ans: str = self.ask_if(
-                    f"Skipping `{invalid_branches[0]}` " +
+                    f"Skipping {bold(invalid_branches[0])} " +
                     "which is not a local branch (perhaps it has been deleted?).\n" +
                     "Slide it out from the definition file?" +
                     get_pretty_choices("y", "e[dit]", "N"), opt_yes_msg=None, opt_yes=False)
             else:
                 ans = self.ask_if(
-                    f"Skipping {', '.join(f'`{branch}`' for branch in invalid_branches)}"
+                    f"Skipping {', '.join(f'{bold(branch)}' for branch in invalid_branches)}"
                     " which are not local branches (perhaps they have been deleted?).\n"
                     "Slide them out from the definition file?" + get_pretty_choices("y", "e[dit]", "N"),
                     opt_yes_msg=None, opt_yes=False)

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -2312,7 +2312,7 @@ class MacheteClient:
                     raise e
             print(fmt(ok_str))
 
-        self.__annotations[head] = Annotation(f'PR #{bold(str(pr.number))}')
+        self.__annotations[head] = Annotation(f'PR #{pr.number}')
         self.save_definition_file()
 
     def __handle_diverged_and_newer_state(

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1138,7 +1138,7 @@ class MacheteClient:
         current_branch = self.__git.get_current_branch_or_none()
         if current_branch and current_branch in branches_to_delete:
             branches_to_delete = excluding(branches_to_delete, [current_branch])
-            print(fmt(f"Skipping current branch `{current_branch}`"))
+            print(fmt(f"Skipping current branch {bold(current_branch)}"))
         if branches_to_delete:
             branches_merged_to_head = self.__git.get_merged_local_branches()
 
@@ -1147,7 +1147,7 @@ class MacheteClient:
                 remote_branch = self.__git.get_strict_counterpart_for_fetching_of_branch(branch)
                 is_merged_to_remote = self.__git.is_ancestor_or_equal(branch.full_name(),
                                                                       remote_branch.full_name()) if remote_branch else True
-                msg_core = f"{bold(branch)} (merged to HEAD{'' if is_merged_to_remote else f', but not merged to {remote_branch}'})"
+                msg_core = f"{bold(branch)} (merged to HEAD{'' if is_merged_to_remote else f', but not merged to {bold(remote_branch)}'})"
                 msg = f"Delete branch {msg_core}?" + get_pretty_choices('y', 'N', 'q')
                 opt_yes_msg = f"Deleting branch {msg_core}"
                 ans = self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes)
@@ -2067,7 +2067,7 @@ class MacheteClient:
                             verbose=verbose,
                             switch_head_if_new_branch=False)
                     if pr not in checked_out_prs:
-                        print(fmt(f"Pull request `#{pr.number}` checked out at local branch `{pr.head}`"))
+                        print(fmt(f"Pull request {bold('#' + str(pr.number))} checked out at local branch {bold(pr.head)}"))
                         checked_out_prs.append(pr)
 
         debug('Current GitHub user is ' + (current_user or '<none>'))
@@ -2075,7 +2075,7 @@ class MacheteClient:
         if len(applicable_prs) == 1:
             self.__git.checkout(LocalBranchShortName.of(pr.head))
             if verbose:
-                print(fmt(f"Switched to local branch `{pr.head}`"))
+                print(fmt(f"Switched to local branch {bold(pr.head)}"))
 
     @staticmethod
     def __get_path_from_pr_chain(current_pr: GitHubPullRequest, all_open_prs: List[GitHubPullRequest]) -> List[LocalBranchShortName]:

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1488,9 +1488,9 @@ class MacheteClient:
         for pr in prs:
             if LocalBranchShortName.of(pr.head) in self.managed_branches:
                 debug(f'{pr} corresponds to a managed branch')
-                anno: str = f'PR #{bold(str(pr.number))}'
+                anno: str = f'PR #{pr.number}'
                 if pr.user != current_user:
-                    anno += f' ({bold(pr.user)})'
+                    anno += f' ({pr.user})'
                 upstream: Optional[LocalBranchShortName] = self.up_branch.get(LocalBranchShortName.of(pr.head))
                 if pr.base != upstream:
                     warn(f'branch {bold(pr.head)} has a different base in PR #{bold(str(pr.number))} ({bold(pr.base)}) '
@@ -2177,9 +2177,9 @@ class MacheteClient:
             print(f'The base branch of PR #{bold(str(pr.number))} is already {bold(new_base)}')
 
         if self.__annotations.get(head) and self.__annotations[head].qualifiers_text:
-            self.__annotations[head] = Annotation(f'PR #{bold(str(pr.number))} ' + self.__annotations[head].qualifiers_text)
+            self.__annotations[head] = Annotation(f'PR #{pr.number} ' + self.__annotations[head].qualifiers_text)
         else:
-            self.__annotations[head] = Annotation(f'PR #{bold(str(pr.number))}')
+            self.__annotations[head] = Annotation(f'PR #{pr.number}')
         self.save_definition_file()
 
     def __derive_github_domain(self) -> str:
@@ -2282,7 +2282,7 @@ class MacheteClient:
         print(f'Creating a {"draft " if opt_draft else ""}PR from {bold(head)} to {bold(base)}... ', end='', flush=True)
         pr: GitHubPullRequest = create_pull_request(domain, org, repo, head=head, base=base, title=commits[0].subject,
                                                     description=description, draft=opt_draft)
-        print(fmt(f'{ok_str}, see <b>{pr.html_url}</b>'))
+        print(fmt(f'{ok_str}, see `{pr.html_url}`'))
 
         milestone_path: str = self.__git.get_main_git_subpath('info', 'milestone')
         milestone: str = utils.slurp_file_or_empty(milestone_path).strip()

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -247,7 +247,7 @@ class MacheteClient:
             ) -> None:
         if branch in self.managed_branches:
             raise MacheteException(
-                f"Branch `{branch}` already exists in the tree of branch dependencies")
+                f"Branch {bold(branch)} already exists in the tree of branch dependencies")
 
         if opt_onto:
             self.expect_in_managed_branches(opt_onto)
@@ -256,10 +256,10 @@ class MacheteClient:
             remote_branch: Optional[RemoteBranchShortName] = self.__git.get_sole_remote_branch(branch)
             if remote_branch:
                 common_line = (
-                    f"A local branch `{branch}` does not exist, but a remote "
-                    f"branch `{remote_branch}` exists.\n")
-                msg = common_line + f"Check out `{branch}` locally?" + get_pretty_choices('y', 'N')
-                opt_yes_msg = common_line + f"Checking out `{branch}` locally..."
+                    f"A local branch {bold(branch)} does not exist, but a remote "
+                    f"branch {bold(remote_branch)} exists.\n")
+                msg = common_line + f"Check out {bold(branch)} locally?" + get_pretty_choices('y', 'N')
+                opt_yes_msg = common_line + f"Checking out {bold(branch)} locally..."
                 if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
                     self.__git.create_branch(branch, remote_branch.full_name(), switch_head=switch_head_if_new_branch)
                 else:
@@ -268,8 +268,8 @@ class MacheteClient:
                 # specified via `--onto`, we'll try to infer it now.
             else:
                 out_of = LocalBranchShortName.of(opt_onto).full_name() if opt_onto else HEAD
-                out_of_str = f"`{opt_onto}`" if opt_onto else "the current HEAD"
-                msg = (f"A local branch `{branch}` does not exist. Create (out "
+                out_of_str = f"{bold(opt_onto)}" if opt_onto else "the current HEAD"
+                msg = (f"A local branch {bold(branch)} does not exist. Create (out "
                        f"of {out_of_str})?" + get_pretty_choices('y', 'N'))
                 opt_yes_msg = (f"A local branch `{branch}` does not exist. "
                                f"Creating out of {out_of_str}")
@@ -287,7 +287,7 @@ class MacheteClient:
         if opt_as_root or not self.__roots:
             self.__roots += [branch]
             if verbose:
-                print(fmt(f"Added branch `{branch}` as a new root"))
+                print(fmt(f"Added branch {bold(branch)} as a new root"))
         else:
             if not opt_onto:
                 upstream = self.__infer_upstream(
@@ -296,16 +296,16 @@ class MacheteClient:
                     reject_reason_message="this candidate is not a managed branch")
                 if not upstream:
                     raise MacheteException(
-                        f"Could not automatically infer upstream (parent) branch for `{branch}`.\n"
+                        f"Could not automatically infer upstream (parent) branch for {bold(branch)}.\n"
                         "You can either:\n"
                         "1) specify the desired upstream branch with `--onto` or\n"
-                        f"2) pass `--as-root` to attach `{branch}` as a new root or\n"
+                        f"2) pass `--as-root` to attach {bold(branch)} as a new root or\n"
                         "3) edit the definition file manually with `git machete edit`")
                 else:
-                    msg = (f"Add `{branch}` onto the inferred upstream (parent) "
-                           f"branch `{upstream}`?" + get_pretty_choices('y', 'N'))
-                    opt_yes_msg = (f"Adding `{branch}` onto the inferred upstream"
-                                   f" (parent) branch `{upstream}`")
+                    msg = (f"Add {bold(branch)} onto the inferred upstream (parent) "
+                           f"branch {bold(upstream)}?" + get_pretty_choices('y', 'N'))
+                    opt_yes_msg = (f"Adding {bold(branch)} onto the inferred upstream"
+                                   f" (parent) branch {bold(upstream)}")
                     if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
                         opt_onto = upstream
                     else:
@@ -317,7 +317,7 @@ class MacheteClient:
             else:
                 self.__down_branches[opt_onto] = [branch]
             if verbose:
-                print(fmt(f"Added branch `{branch}` onto `{opt_onto}`"))
+                print(fmt(f"Added branch {bold(branch)} onto {bold(opt_onto)}"))
 
         self.managed_branches += [branch]
         self.save_definition_file()

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -11,7 +11,7 @@ from git_machete import utils
 from git_machete.constants import (MAX_COUNT_FOR_INITIAL_LOG,
                                    GitFormatPatterns, SyncToRemoteStatuses)
 from git_machete.exceptions import MacheteException
-from git_machete.utils import (AnsiEscapeCodes, CommandResult, colored, debug,
+from git_machete.utils import (AnsiEscapeCodes, bold, CommandResult, colored, debug,
                                fmt)
 
 
@@ -725,7 +725,8 @@ class GitContext:
         remote_branch = self.get_currently_rebased_branch_or_none()
         if remote_branch:
             raise MacheteException(
-                f"Rebase of `{remote_branch}` in progress. Conclude the rebase first with `git rebase --continue` or `git rebase --abort`.")
+                f"Rebase of {bold(remote_branch)} in progress. "
+                f"Conclude the rebase first with `git rebase --continue` or `git rebase --abort`.")
         if self.is_am_in_progress():
             raise MacheteException(
                 "`git am` session in progress. Conclude `git am` first with `git am --continue` or `git am --abort`.")

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -11,7 +11,7 @@ from git_machete import utils
 from git_machete.constants import (MAX_COUNT_FOR_INITIAL_LOG,
                                    GitFormatPatterns, SyncToRemoteStatuses)
 from git_machete.exceptions import MacheteException
-from git_machete.utils import (AnsiEscapeCodes, CommandResult, bold, colored, debug, fmt)
+from git_machete.utils import (AnsiEscapeCodes, CommandResult, colored, debug, fmt)
 
 
 class AnyRevision(str):
@@ -724,7 +724,7 @@ class GitContext:
         remote_branch = self.get_currently_rebased_branch_or_none()
         if remote_branch:
             raise MacheteException(
-                f"Rebase of {bold(remote_branch)} in progress. "
+                f"Rebase of {utils.bold(remote_branch)} in progress. "
                 f"Conclude the rebase first with `git rebase --continue` or `git rebase --abort`.")
         if self.is_am_in_progress():
             raise MacheteException(

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -11,8 +11,7 @@ from git_machete import utils
 from git_machete.constants import (MAX_COUNT_FOR_INITIAL_LOG,
                                    GitFormatPatterns, SyncToRemoteStatuses)
 from git_machete.exceptions import MacheteException
-from git_machete.utils import (AnsiEscapeCodes, bold, CommandResult, colored, debug,
-                               fmt)
+from git_machete.utils import (AnsiEscapeCodes, CommandResult, bold, colored, debug, fmt)
 
 
 class AnyRevision(str):

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -11,7 +11,8 @@ from git_machete import utils
 from git_machete.constants import (MAX_COUNT_FOR_INITIAL_LOG,
                                    GitFormatPatterns, SyncToRemoteStatuses)
 from git_machete.exceptions import MacheteException
-from git_machete.utils import (AnsiEscapeCodes, CommandResult, colored, debug, fmt)
+from git_machete.utils import (AnsiEscapeCodes, CommandResult, colored, debug,
+                               fmt)
 
 
 class AnyRevision(str):

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from git_machete.exceptions import (MacheteException,
                                     UnprocessableEntityHTTPError)
 from git_machete.git_operations import GitContext, LocalBranchShortName
-from git_machete.utils import debug, fmt, warn
+from git_machete.utils import bold, debug, fmt, warn
 
 GITHUB_TOKEN_ENV_VAR = 'GITHUB_TOKEN'
 DEFAULT_GITHUB_DOMAIN = "github.com"
@@ -261,8 +261,8 @@ def __fire_github_api_request(domain: str, method: str, path: str,
             warn(f'GitHub API returned `{err.code}` HTTP status with error message: `{err.reason}`. \n'
                  'It looks like the organization or repository name got changed recently and is outdated.\n'
                  'Inferring current organization or repository... '
-                 f'New organization = `{current_repo_and_org.split("/")[0]}`, '
-                 f'new repository = `{current_repo_and_org.split("/")[1]}`.\n'
+                 f'New organization = {bold(current_repo_and_org.split("/")[0])}, '
+                 f'new repository = {bold(current_repo_and_org.split("/")[1])}.\n'
                  'You can update your remote repository via: `git remote set-url <remote_name> <new_repository_url>`.',
                  end='')
             return __fire_github_api_request(domain=domain, method=method, path=new_path, token=token, request_body=request_body)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -127,7 +127,7 @@ class TestGithub:
         |
         o-branch-1
           |
-          o-feature *  PR #15 (github_user) WRONG PR BASE or MACHETE PARENT? PR has 'root' rebase=no push=no
+          o-feature *  PR #15 (github_user) WRONG PR BASE or MACHETE PARENT? PR has root rebase=no push=no
         """
         assert_command(
             ['status'],


### PR DESCRIPTION
Commands to check:

- [x] add
- [x] advance
- [x] anno
- [x] clean
- [x] config
- [x] delete-unmanaged
- [x] diff
- [x] discover
- [x] edit
- [x] file
- [x] fork-point
- [x] format
- [x] github
- [x] go
- [x] help
- [x] hooks
- [x] is-managed
- [x] list
- [x] log
- [x] reapply
- [x] show
- [x] slide-out
- [x] squash
- [x] status
- [x] traverse
- [x] update
- [x] version