### PR TITLE
Pin Homebrew version for `ci/homebrew/ci-deploy.sh`

### DIFF
--- a/ci/checks/prohibit-strings-with-backslash-continuation.sh
+++ b/ci/checks/prohibit-strings-with-backslash-continuation.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-if git grep -n "^[^']*'[^s][^']*\\\\$" || git grep -n '^[^"]*"[^"]*\\$'; then
+if git grep -n "^[^']*'[^s][^']*\\\\$" -- '*.py' || git grep -n '^[^"]*"[^"]*\\$'  -- '*.py'; then
   echo 'The above lines apparently contains a backslash continuation within the string.'
   echo 'This might lead to unwanted whitespace making its way into strings, see https://github.com/VirtusLab/git-machete/issues/784'
   echo "Change into  '...' \\  or  \"...\" \\  style of continuation (the string must be closed within the containing line)."

--- a/ci/homebrew/ci-deploy.sh
+++ b/ci/homebrew/ci-deploy.sh
@@ -2,10 +2,15 @@
 
 set -e -o pipefail -u -x
 
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" < /dev/null
+HOMEBREW_VERSION=4.0.13
+
+NONINTERACTIVE=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# https://stackoverflow.com/questions/54912857/how-do-i-install-old-version-of-homebrew-itself-not-the-formula
+(cd /home/linuxbrew/.linuxbrew/Homebrew; git checkout $HOMEBREW_VERSION)
 ## The two lines below are added to avoid ->  Warning: /home/linuxbrew/.linuxbrew/bin is not in your PATH
 (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> /home/circleci/.bash_profile
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+brew --version
 
 if [[ ${1-} == "--dry-run" || ${CIRCLE_BRANCH-} != "master" ]]; then
   do_push=false

--- a/ci/tox/.env-sample
+++ b/ci/tox/.env-sample
@@ -4,6 +4,6 @@ PYTHON_VERSION=3.8
 
 # Vars for `docker-compose run`
 BUILD_SPHINX_HTML=false
-CHECK_DOCS_UP_TO_DATE=false
 CHECK_COVERAGE=false
+CHECK_DOCS_UP_TO_DATE=false
 CHECK_PEP8=false

--- a/ci/tox/docker-compose.yml
+++ b/ci/tox/docker-compose.yml
@@ -10,8 +10,8 @@ services:
         - python_version=${PYTHON_VERSION:-0.0.0}
     environment:
       - BUILD_SPHINX_HTML=${BUILD_SPHINX_HTML:-false}
-      - CHECK_DOCS_UP_TO_DATE=${CHECK_DOCS_UP_TO_DATE:-false}
       - CHECK_COVERAGE=${CHECK_COVERAGE:-false}
+      - CHECK_DOCS_UP_TO_DATE=${CHECK_DOCS_UP_TO_DATE:-false}
       - CHECK_PEP8=${CHECK_PEP8:-false}
     volumes:
       # Host path is relative to current directory, not build-context

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -1078,7 +1078,7 @@ If \fB\&.git/info/reviewers\fP file is present, its contents (one GitHub login p
 Creates the new PR as a draft.
 .UNINDENT
 .TP
-.B \fBretarget\-pr [\-b|\-\-branch=<branch> | \-\-ignore\-if\-missing]\fP:
+.B \fBretarget\-pr [\-b|\-\-branch=<branch>] [\-\-ignore\-if\-missing]\fP:
 Sets the base of the current (or specified) branch\(aqs PR to upstream (parent) branch, as seen by git machete (see \fBgit machete show up\fP).
 .sp
 \fBOptions:\fP

--- a/docs/source/cli_help/github.rst
+++ b/docs/source/cli_help/github.rst
@@ -57,7 +57,7 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
 
     --draft    Creates the new PR as a draft.
 
-``retarget-pr [-b|--branch=<branch> | --ignore-if-missing]``:
+``retarget-pr [-b|--branch=<branch>] [--ignore-if-missing]``:
     Sets the base of the current (or specified) branch's PR to upstream (parent) branch, as seen by git machete (see ``git machete show up``).
 
     **Options:**

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -606,7 +606,7 @@ long_docs: Dict[str, str] = {
                  <b>--draft</b>
               Creates the new PR as a draft.
 
-           `retarget-pr [-b|--branch=<branch> | --ignore-if-missing]`:
+           `retarget-pr [-b|--branch=<branch>] [--ignore-if-missing]`:
  
               Sets the base of the current (or specified) branch's PR to upstream (parent) branch, as seen by git machete (see `git machete show up`).
 


### PR DESCRIPTION
To avoid errors stemming from broken compatibility in Homebrew updates, like https://github.com/Homebrew/brew/issues/15245