### PR TITLE
Use sh instead of bash in tests

### DIFF
--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,7 +1,7 @@
 from .base_test import BaseTest
 from .mockers import assert_success, launch_command, overridden_environment
 
-dummy_editor = "bash -c 'echo foo > $1' 'ignored_$0'"
+dummy_editor = "sh -c 'echo foo > $1' 'ignored_$0'"
 
 
 class TestEdit(BaseTest):
@@ -18,7 +18,7 @@ class TestEdit(BaseTest):
             assert_success(
                 ["edit"],
                 """
-                Opening '$GIT_EDITOR' (bash -c 'echo foo > $1' 'ignored_$0').
+                Opening '$GIT_EDITOR' (sh -c 'echo foo > $1' 'ignored_$0').
                 To override this choice, use GIT_MACHETE_EDITOR env var, e.g. export GIT_MACHETE_EDITOR=vi.
 
                 See git machete help edit and git machete edit --debug for more details.

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -67,7 +67,7 @@ class TestStatus(BaseTest):
             """
         rewrite_definition_file(body)
 
-        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/bash\ngit ls-tree $1 | wc -l | sed 's/ *//'")
+        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/sh\ngit ls-tree $1 | wc -l | sed 's/ *//'")
         assert_success(
             ["status"],
             """
@@ -99,7 +99,7 @@ class TestStatus(BaseTest):
             """
         )
 
-        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/bash\necho '    '")
+        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/sh\necho '    '")
         assert_success(
             ["status"],
             """
@@ -109,7 +109,7 @@ class TestStatus(BaseTest):
             """
         )
 
-        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/bash\nexit 1")
+        self.repo_sandbox.write_to_file(".git/hooks/machete-status-branch", "#!/bin/sh\nexit 1")
         assert_success(
             ["status"],
             """


### PR DESCRIPTION
8adfd5f (Add missing tests for yellow-edge cases, among others, 2023-04-29) and 27183a2 (Add missing tests - vol. 3, 2023-05-01) adds tests that refer to bash, while it does not use any functionality that requires bash. This results in test failures when bash is not installed.

Use sh instead which is more commonly available and more portable.