### PR TITLE
Fix packaging of non-Python files into sdist/bdist_wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
-include LICENSE
 
-# As for now, used just by the Homebrew formula
-recursive-include completion *
+# So that tests aren't included in sdist
+prune tests/
+
+# sdist could work with just these entries in MANIFEST.in;
+# bdist_wheel requires both these entries AND including them in `packages` in setup.py
+recursive-include completion/ *
 include           docs/man/git-machete.1

--- a/ci/tox/build-context/run.sh
+++ b/ci/tox/build-context/run.sh
@@ -28,6 +28,18 @@ fi
 
 tox -e "$TOX_ENV_LIST"
 
-$PYTHON setup.py install --user
-PATH=$PATH:$HOME/.local/bin/
+$PYTHON setup.py sdist bdist_wheel
+
+tar tvf dist/git-machete-*.tar.gz | grep docs/man/git-machete.1
+unzip -v dist/git_machete-*.whl   | grep docs/man/git-machete.1
+
+$PYTHON -m venv venv/sdist/
+$PYTHON -m venv venv/bdist_wheel/
+
+. venv/sdist/bin/activate
+pip install dist/git-machete-*.tar.gz
+git machete --version
+
+. venv/bdist_wheel/bin/activate
+pip install dist/git_machete-*.whl
 git machete --version

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     url='https://github.com/VirtusLab/git-machete',
     license='MIT',
     keywords='git',
-    packages=['git_machete'],
+    # Non-python directories are only included in `packages` for the sake of bdist_wheel;
+    # they have apparently no effect on sdists (only MANIFEST.in matters).
+    packages=['git_machete', 'completion', 'docs/man'],
     entry_points={
         'console_scripts': [
             'git-machete = git_machete.bin:main'
@@ -38,6 +40,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent'
     ],
-    options={'bdist_wheel': {'universal': '1'}},
+    # This is a pure-Python but NOT universal wheel:
+    # https://realpython.com/python-wheels/#different-types-of-wheels
+    options={'bdist_wheel': {'universal': False}},
     include_package_data=True
 )


### PR DESCRIPTION
```
rm -rf build/ dist/ *.egg-info/ && python setup.py sdist bdist_wheel && tar tvf dist/*.tar.gz && unzip -v dist/*.whl
```