### PR TITLE
Use GitHub PR template

### DIFF
--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Sep 07, 2023" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Sep 22, 2023" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.18.3
 .sp
@@ -1108,7 +1108,7 @@ Checkout open PRs for the current user associated with the GitHub token.
 Creates a PR for the current branch, using the upstream (parent) branch as the PR base.
 Once the PR is successfully created, annotates the current branch with the new PR\(aqs number.
 .sp
-If \fB\&.git/info/description\fP file is present, its contents are used as PR description.
+If \fB\&.git/info/description\fP or \fB\&.github/pull_request_template.md\fP file is present, its contents are used as PR description.
 If \fB\&.git/info/milestone\fP file is present, its contents (a single number \-\-\- milestone id) are used as milestone.
 If \fB\&.git/info/reviewers\fP file is present, its contents (one GitHub login per line) are used to set reviewers.
 .sp

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -49,7 +49,7 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
     Creates a PR for the current branch, using the upstream (parent) branch as the PR base.
     Once the PR is successfully created, annotates the current branch with the new PR's number.
 
-    If ``.git/info/description`` file is present, its contents are used as PR description.
+    If ``.git/info/description`` or ``.github/pull_request_template.md`` file is present, its contents are used as PR description.
     If ``.git/info/milestone`` file is present, its contents (a single number --- milestone id) are used as milestone.
     If ``.git/info/reviewers`` file is present, its contents (one GitHub login per line) are used to set reviewers.
 

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -6,6 +6,7 @@ import shlex
 import shutil
 import sys
 from collections import OrderedDict
+from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from . import git_config_keys, utils
@@ -2339,7 +2340,12 @@ class MacheteClient:
         debug('current GitHub user is ' + (current_user or '<none>'))
 
         description_path = self.__git.get_main_git_subpath('info', 'description')
-        description: str = utils.slurp_file_or_empty(description_path)
+        try:
+            description = Path(description_path).read_text()
+        except FileNotFoundError:
+            # https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
+            pr_template = Path(self.__git.get_root_dir()).joinpath('.github', 'pull_request_template.md')
+            description = utils.slurp_file_or_empty(str(pr_template))
 
         fork_point = self.fork_point(head, use_overrides=True)
         commits: List[GitLogEntry] = self.__git.get_commits_between(fork_point, head)

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -617,7 +617,7 @@ long_docs: Dict[str, str] = {
               Creates a PR for the current branch, using the upstream (parent) branch as the PR base.
               Once the PR is successfully created, annotates the current branch with the new PR's number.
 
-              If `.git/info/description` file is present, its contents are used as PR description.
+              If `.git/info/description` or `.github/pull_request_template.md` file is present, its contents are used as PR description.
               If `.git/info/milestone` file is present, its contents (a single number — milestone id) are used as milestone.
               If `.git/info/reviewers` file is present, its contents (one GitHub login per line) are used to set reviewers.
 


### PR DESCRIPTION
GH repos can have multiple PR templates; this uses the default one if it's available.

`.git/info/description` is checked first and is used if present (even if empty).