### PR TITLE
Fix the warning on `navigation_with_keys` coming from pydata-sphinx-theme 0.14.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,9 @@ html_theme_options = {
         "image_dark": "../../graphics/logo/svg/512x512-dark.svg",
         "text": "git-machete v" + release,
     },
+    # See https://github.com/pydata/pydata-sphinx-theme/issues/1492.
+    # Mostly added to avoid a warning coming from pydata-sphinx-theme==0.14.2.
+    "navigation_with_keys": False,
 }
 
 # To make sure the dark logo is included in _static/ directory in the generated docs

--- a/requirements/sphinx-docs.txt
+++ b/requirements/sphinx-docs.txt
@@ -1,2 +1,7 @@
+# Dependency of `sphinx-book-theme`.
+# Added explicitly after https://github.com/pydata/pydata-sphinx-theme/pull/1503
+# broke the build despite no explicit update to deps.
+pydata-sphinx-theme==0.14.2
+
 sphinx==6.2.1
 sphinx-book-theme==1.0.1


### PR DESCRIPTION
Needed due to https://app.circleci.com/pipelines/github/VirtusLab/git-machete/4428/workflows/907b16e9-8cee-4a87-838f-87e8a47803b7/jobs/25745