### PR TITLE
Fix failures in Homebrew dry-run deploys

### DIFF
--- a/ci/homebrew/ci-deploy.sh
+++ b/ci/homebrew/ci-deploy.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u -x
 
-HOMEBREW_VERSION=4.0.26
+HOMEBREW_VERSION=4.1.21
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/VirtusLab/git-machete/4465/workflows/44aea054-4315-461c-bb27-b8bed979f1e0/jobs/26167:

```
==> Installing git-machete
Error: An exception occurred within a child process:
  NameError: undefined local variable or method `std_pip_args' for #<Formulary::FormulaNamespace11e552e1e94268deda5ff5d9f0561e61::GitMachete:0x000055b68455d530>
Did you mean?  std_go_args
+ ((  i < attempts  ))
+ echo 'Retrying the installation...'
Retrying the installation...
+ i=2
+ sleep 60
+ true
+ brew install --build-from-source --formula /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/g/git-machete.rb
```