### PR TITLE
Fix docs for `restack-{pr,mr}`

### DIFF
--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Apr 15, 2024" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Apr 19, 2024" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.25.1
 .sp
@@ -1023,9 +1023,9 @@ Perform the following sequence of actions:
 .IP 1. 3
 If the PR for the current branch is ready for review, it gets converted to a draft.
 .IP 2. 3
-The branch is (force\-)pushed into remote.
-.IP 3. 3
 The PR is retargeted to its upstream (parent) branch, as in \fBretarget\-pr\fP\&.
+.IP 3. 3
+The branch is (force\-)pushed into remote.
 .IP 4. 3
 If the PR has been converted to draft in step 1, it\(aqs reverted to ready for review state.
 .UNINDENT
@@ -1251,9 +1251,9 @@ Perform the following sequence of actions:
 .IP 1. 3
 If the MR for the current branch is ready for review, it gets converted to a draft.
 .IP 2. 3
-The branch is (force\-)pushed into remote.
-.IP 3. 3
 The MR is retargeted to its upstream (parent) branch, as in \fBretarget\-mr\fP\&.
+.IP 3. 3
+The branch is (force\-)pushed into remote.
 .IP 4. 3
 If the MR has been converted to draft in step 1, it\(aqs reverted to ready for review state.
 .UNINDENT

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -102,8 +102,8 @@ Creates, checks out and manages GitHub PRs while keeping them reflected in branc
     Perform the following sequence of actions:
 
     #. If the PR for the current branch is ready for review, it gets converted to a draft.
-    #. The branch is (force-)pushed into remote.
     #. The PR is retargeted to its upstream (parent) branch, as in ``retarget-pr``.
+    #. The branch is (force-)pushed into remote.
     #. If the PR has been converted to draft in step 1, it's reverted to ready for review state.
 
     The drafting/undrafting is useful in case the GitHub repository has set up `CODEOWNERS <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners>`_.

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -103,8 +103,8 @@ Creates, checks out and manages GitLab MRs while keeping them reflected in branc
     Perform the following sequence of actions:
 
     #. If the MR for the current branch is ready for review, it gets converted to a draft.
-    #. The branch is (force-)pushed into remote.
     #. The MR is retargeted to its upstream (parent) branch, as in ``retarget-mr``.
+    #. The branch is (force-)pushed into remote.
     #. If the MR has been converted to draft in step 1, it's reverted to ready for review state.
 
     The drafting/undrafting is useful in case the GitLab project has set up `code owners <https://docs.gitlab.com/ee/user/project/codeowners/>`_.

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -616,9 +616,9 @@ long_docs: Dict[str, str] = {
 
                  * If the PR for the current branch is ready for review, it gets converted to a draft.
 
-                 * The branch is (force-)pushed into remote.
-
                  * The PR is retargeted to its upstream (parent) branch, as in `retarget-pr`.
+
+                 * The branch is (force-)pushed into remote.
 
                  * If the PR has been converted to draft in step 1, it's reverted to ready for review state.
 
@@ -797,9 +797,9 @@ long_docs: Dict[str, str] = {
 
                  * If the MR for the current branch is ready for review, it gets converted to a draft.
 
-                 * The branch is (force-)pushed into remote.
-
                  * The MR is retargeted to its upstream (parent) branch, as in `retarget-mr`.
+
+                 * The branch is (force-)pushed into remote.
 
                  * If the MR has been converted to draft in step 1, it's reverted to ready for review state.
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1224

## Full chain of PRs as of 2024-04-19

* PR #1225: `fix/1222-docs` ➔ `develop`
* PR #1224: `develop` ➔ `master`

<!-- end git-machete generated -->
