### PR TITLE
Fix incorrect re.sub invocation

### DIFF
--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -101,7 +101,7 @@ def find_executable(executable: str) -> Optional[str]:
 
 
 def compact_dict(d: Dict[str, Any]) -> Dict[str, str]:
-    return {k: re.sub('\n +', ' ', str(v), re.MULTILINE) for k, v in d.items()}
+    return {k: re.sub('\n +', ' ', str(v)) for k, v in d.items()}
 
 
 def debug(msg: str) -> None:


### PR DESCRIPTION
The fourth argument to `re.sub` is the `count` argument and it specifies the maximum number of pattern occurrences to be replaced.
So in this case, the `re.MULTILINE` flag is not used but instead interpreted as an integer (8) so only 8 replacements can be done.

BTW, `re.MULTILINE` only affects `^` and `$`, so I guess it's not useful in this case.
