### PR TITLE
Set --no-edit-merge flag automatically when using -y in traverse

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.25.3
 
-- fixed: `-y` option in `git machete traverse` should set automatically `--no-edit-merge` flag, to retain behavior when the `update=merge` qualifier is set (contributed by @gjulianm)
+- fixed: `-y` option in `git machete traverse` automatically sets `--no-edit-merge` flag, to retain behavior when the `update=merge` qualifier is set (contributed by @gjulianm)
 
 ## New in git-machete 3.25.2
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.25.3
 
+- fixed: `-y` option in `git machete traverse` should set automatically `--no-edit-merge` flag, to retain behavior when the `update=merge` qualifier is set (contributed by @gjulianm)
+
 ## New in git-machete 3.25.2
 
 - fixed: Homebrew deploys

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Apr 21, 2024" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Apr 24, 2024" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.25.3
 .sp

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -510,7 +510,8 @@ def update_cli_options_using_parsed_args(
         elif opt == "yes":
             cli_opts.opt_yes = True
 
-    if cli_opts.opt_n and cli_opts.opt_merge:
+    if cli_opts.opt_n or cli_opts.opt_yes:
+        # Set no-edit-merge as the default, as some branches might have a merge strategy even without --merge set
         cli_opts.opt_no_edit_merge = True
     if not cli_opts.opt_merge:
         if cli_opts.opt_yes or cli_opts.opt_n:

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -790,6 +790,43 @@ class TestTraverse(BaseTest):
             """,
         )
 
+    def test_traverse_with_merge_annotation_and_yes_option(self, mocker: MockerFixture) -> None:
+        (
+            self.repo_sandbox.remove_remote()
+            .new_branch("develop")
+            .commit()
+            .new_branch("mars")
+            .commit()
+            .new_branch("snickers")
+            .commit()
+            .check_out("mars")
+            .commit()
+            .check_out("develop")
+            .commit()
+        )
+
+        body: str = """
+            develop
+                mars update=merge
+                    snickers
+            """
+        rewrite_branch_layout_file(body)
+
+        self.patch_symbol(mocker, "builtins.input", mock_input_returning("q"))
+        launch_command("traverse")
+        self.patch_symbol(mocker, "builtins.input", mock_input_returning("n", "q"))
+        launch_command("traverse")
+        launch_command("traverse", "--start-from=root", "--yes"),  # --yes should imply --no-edit-merge, if it doesn't the command will fail
+        assert_success(["status"],
+            """
+            develop
+            |
+            o-mars  update=merge
+              |
+              o-snickers *
+            """,
+        )
+
     def test_traverse_qualifiers_no_push(self) -> None:
         self.setup_standard_tree()
 

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -790,7 +790,7 @@ class TestTraverse(BaseTest):
             """,
         )
 
-    def test_traverse_with_merge_annotation_and_yes_option(self, mocker: MockerFixture) -> None:
+    def test_traverse_with_merge_annotation_and_yes_option(self) -> None:
         (
             self.repo_sandbox.remove_remote()
             .new_branch("develop")
@@ -812,11 +812,10 @@ class TestTraverse(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        self.patch_symbol(mocker, "builtins.input", mock_input_returning("q"))
-        launch_command("traverse")
-        self.patch_symbol(mocker, "builtins.input", mock_input_returning("n", "q"))
-        launch_command("traverse")
-        launch_command("traverse", "--start-from=root", "--yes"),  # --yes should imply --no-edit-merge, if it doesn't the command will fail
+        with overridden_environment(GIT_EDITOR='false'):
+            # --yes should imply --no-edit-merge, if it doesn't then the command will fail due to a non-zero exit code from the editor
+            launch_command("traverse", "--start-from=root", "--yes"),
+
         assert_success(
             ["status"],
             """

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -817,7 +817,8 @@ class TestTraverse(BaseTest):
         self.patch_symbol(mocker, "builtins.input", mock_input_returning("n", "q"))
         launch_command("traverse")
         launch_command("traverse", "--start-from=root", "--yes"),  # --yes should imply --no-edit-merge, if it doesn't the command will fail
-        assert_success(["status"],
+        assert_success(
+            ["status"],
             """
             develop
             |

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -72,35 +72,6 @@ class TestUpdate(BaseTest):
         assert self.repo_sandbox.is_ancestor_or_equal(old_level_1_commit_hash, "level-1-branch")
         assert self.repo_sandbox.is_ancestor_or_equal("level-0-branch", "level-1-branch")
 
-    def test_update_by_merge_yes_option_forces_no_edit_merge(self) -> None:
-
-        (
-            self.repo_sandbox.new_branch("level-0-branch")
-            .commit("Basic commit.")
-            .new_branch("level-1-branch")
-            .commit("Only level-1 commit.")
-            .new_branch("level-2-branch")
-            .commit("Only level-2 commit.")
-            .check_out("level-0-branch")
-            .commit("New commit on level-0-branch")
-        )
-        body: str = \
-            """
-            level-0-branch
-                level-1-branch
-                    level-2-branch
-            """
-        rewrite_branch_layout_file(body)
-
-        self.repo_sandbox.check_out("level-1-branch")
-        old_level_1_commit_hash = self.repo_sandbox.get_current_commit_hash()
-        # If -y is specified, --no-edit-merge is implied. This test ensures that, if we got a message edit window
-        # the test would fail as the merge is not performed fully without interaction.
-        launch_command("update", "--merge", "-y")
-
-        assert self.repo_sandbox.is_ancestor_or_equal(old_level_1_commit_hash, "level-1-branch")
-        assert self.repo_sandbox.is_ancestor_or_equal("level-0-branch", "level-1-branch")
-
     def test_update_drops_empty_commits(self) -> None:
         """
         Verify that 'git machete update' drops effectively-empty commits if the underlying git supports that behavior.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -72,6 +72,35 @@ class TestUpdate(BaseTest):
         assert self.repo_sandbox.is_ancestor_or_equal(old_level_1_commit_hash, "level-1-branch")
         assert self.repo_sandbox.is_ancestor_or_equal("level-0-branch", "level-1-branch")
 
+    def test_update_by_merge_yes_option_forces_no_edit_merge(self) -> None:
+
+        (
+            self.repo_sandbox.new_branch("level-0-branch")
+            .commit("Basic commit.")
+            .new_branch("level-1-branch")
+            .commit("Only level-1 commit.")
+            .new_branch("level-2-branch")
+            .commit("Only level-2 commit.")
+            .check_out("level-0-branch")
+            .commit("New commit on level-0-branch")
+        )
+        body: str = \
+            """
+            level-0-branch
+                level-1-branch
+                    level-2-branch
+            """
+        rewrite_branch_layout_file(body)
+
+        self.repo_sandbox.check_out("level-1-branch")
+        old_level_1_commit_hash = self.repo_sandbox.get_current_commit_hash()
+        # If -y is specified, --no-edit-merge is implied. This test ensures that, if we got a message edit window
+        # the test would fail as the merge is not performed fully without interaction.
+        launch_command("update", "--merge", "-y")
+
+        assert self.repo_sandbox.is_ancestor_or_equal(old_level_1_commit_hash, "level-1-branch")
+        assert self.repo_sandbox.is_ancestor_or_equal("level-0-branch", "level-1-branch")
+
     def test_update_drops_empty_commits(self) -> None:
         """
         Verify that 'git machete update' drops effectively-empty commits if the underlying git supports that behavior.


### PR DESCRIPTION
When using `git machete traverse -y`, the behavior is to disable interactive rebase. However, if some branches have the `update=merge` annotation, they will show a merge commit edit window because the corresponding option `--no-edit-merge` is not set automatically. This PR changes that behavior.