### PR TITLE
In `github create-pr`/`gitlab create-mr`, check whether base/target branch for PR/MR exists in remote, instead of fetching the entire remote

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - fixed: `-y` option in `git machete traverse` automatically sets `--no-edit-merge` flag, to retain behavior when the `update=merge` qualifier is set (contributed by @gjulianm)
 - fixed: `push=no` and `slide-out=no` qualifiers now work in `git machete advance` now
 - fixed: `rebase=no` qualifier now works in `git machete slide-out`
+- improved: in `git machete github create-pr`/`gitlab create-mr`, check whether base/target branch for PR/MR exists in remote, instead of fetching the entire remote
 
 ## New in git-machete 3.25.2
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Apr 25, 2024" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Apr 26, 2024" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.25.3
 .sp


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1236

## Full chain of PRs as of 2024-04-25

* PR #1237: `fix/1047-create-pr-fetch-single-refspec` ➔ `fix/qualifiers-outside-traverse`
* PR #1236: `fix/qualifiers-outside-traverse` ➔ `develop`

<!-- end git-machete generated -->
