### PR TITLE
Improve handling of 409/422 HTTP errors from GitHub/GitLab

### DIFF
--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -19,8 +19,7 @@ from .constants import (DISCOVER_DEFAULT_FRESH_BRANCH_COUNT, PICK_FIRST_ROOT,
                         PICK_LAST_ROOT, GitFormatPatterns,
                         SyncToRemoteStatuses)
 from .exceptions import (InteractionStopped, MacheteException,
-                         UnexpectedMacheteException,
-                         UnprocessableEntityOrConflictHTTPError)
+                         UnexpectedMacheteException)
 from .git_operations import (HEAD, AnyBranchName, AnyRevision, BranchPair,
                              ForkPointOverrideData, FullCommitHash, GitContext,
                              GitLogEntry, LocalBranchShortName,
@@ -2651,17 +2650,8 @@ class MacheteClient:
             print(f'Adding {", ".join(bold(reviewer) for reviewer in reviewers)} '
                   f'as reviewer{"s" if len(reviewers) > 1 else ""} to {pr.display_text()}... ',
                   end='', flush=True)
-            try:
-                code_hosting_client.add_reviewers_to_pull_request(pr.number, reviewers)
-            except UnprocessableEntityOrConflictHTTPError as e:
-                if 'Reviews may only be requested from collaborators.' in e.msg:
-                    print()
-                    warn(f"There are some invalid reviewers in {self.__git.get_main_git_subpath('info', 'reviewers')} file.\n"
-                         f"Skipped adding reviewers to {spec.pr_full_name}.")
-                else:
-                    raise UnexpectedMacheteException(str(e))
-            else:
-                print(fmt(ok_str))
+            code_hosting_client.add_reviewers_to_pull_request(pr.number, reviewers)
+            print(fmt(ok_str))
 
         self.__annotations[head] = Annotation(self.__pull_request_annotation(spec, pr, current_user))
         self.save_branch_layout_file()

--- a/git_machete/exceptions.py
+++ b/git_machete/exceptions.py
@@ -3,6 +3,11 @@ from enum import IntEnum
 from git_machete import utils
 
 
+class InteractionStopped(Exception):
+    def __init__(self) -> None:
+        pass
+
+
 class UnderlyingGitException(Exception):
     def __init__(self, msg: str, apply_fmt: bool = True) -> None:
         self.msg: str = utils.fmt(msg) if apply_fmt else msg
@@ -20,25 +25,8 @@ class MacheteException(Exception):
 
 
 class UnexpectedMacheteException(MacheteException):
-    def __init__(self, msg: str) -> None:
-        super().__init__(f"{msg}\n\nConsider posting an issue at https://github.com/VirtusLab/git-machete/issues/new")
-
-
-class InteractionStopped(Exception):
-    def __init__(self) -> None:
-        pass
-
-
-class UnprocessableEntityOrConflictHTTPError(MacheteException):
-    """This exception is raised when GitHub API returns HTTP status code 422 - Unprocessable Entity,
-    or when GitLab returns HTTP status code 409 - Conflict.
-    Such a situation occurs when trying to do something not allowed by GitHub/GitLab,
-    e.g. assigning someone from outside organization as a reviewer
-    or creating a PR/MR for a branch that already has a PR/MR.
-    """
-
-    def __init__(self, msg: str) -> None:
-        super().__init__(msg, apply_fmt=False)
+    def __init__(self, msg: str, apply_fmt: bool = False) -> None:
+        super().__init__(f"{msg}\n\nConsider posting an issue at https://github.com/VirtusLab/git-machete/issues/new", apply_fmt=apply_fmt)
 
 
 class ExitCode(IntEnum):

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -294,8 +294,9 @@ class TestGitHubCreatePR(BaseTest):
             Setting milestone of PR #7 to 42... OK
             Adding github_user as assignee to PR #7... OK
             Adding invalid-user as reviewer to PR #7...
-            Warn: There are some invalid reviewers in .git{os.path.sep}info{os.path.sep}reviewers file.
-            Skipped adding reviewers to pull request.
+            Warn: There are some invalid reviewers (non-collaborators) in .git{os.path.sep}info{os.path.sep}reviewers file.
+            Skipped adding reviewers to the pull request.
+            OK
             """
         )
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1248

## Full chain of PRs as of 2024-05-08

* PR #1249: `fix/code-hosting-unexpected-errors` ➔ `fix/revert-test-coverage`
* PR #1248: `fix/revert-test-coverage` ➔ `develop`

<!-- end git-machete generated -->
