### PR TITLE
Bump twine to 5.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,7 @@ workflows:
           filters:
             branches:
               only:
+                - "/dependabot.pip.*/"
                 - "develop"
                 - "/.*dry-run.*/"
                 - "/hotfix.*/"

--- a/requirements/pypi-deploy.txt
+++ b/requirements/pypi-deploy.txt
@@ -1,3 +1,3 @@
 setuptools==70.1.0
-twine==5.1.0
+twine==5.1.1
 wheel==0.43.0


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1271

## Full chain of PRs as of 2024-06-26

* PR #1273:
  `fix/twine-bump-dry-run` ➔ `develop`
* PR #1271:
  `develop` ➔ `master`

<!-- end git-machete generated -->
