### PR TITLE
git {ref,}log calls: pass --no-show-signature

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - improved: performance of listing commits for red-edge branches on large repos
 - improved: message in case of missing `.git/machete` file suggests to use `git machete git{hub,lab} checkout-{prs,mrs}`
+- fixed: pass `-c log.showSignature=false` to all `git` invocations to hide GPG signatures in logs; if `log.showSignature` were set to a value equivalent to `true` in a user's `git` configuration, the GPG signatures shown in logs would cause errors in `git log` and `git reflog` parsing internal to `git machete` (reported and contributed by @goxberry)
 
 ## New in git-machete 3.26.2
 

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -593,8 +593,8 @@ class GitContext:
                 self.__missing_tracking_branch.add(b_stripped_local)
 
     def __get_log_hashes(self, revision: AnyRevision, max_count: Optional[int]) -> List[FullCommitHash]:
-        opts = ([f"--max-count={str(max_count)}"] if max_count else []) + ["--no-show-signature", "--format=%H", revision.full_name()]
-        return list(map(FullCommitHash.of, utils.get_non_empty_lines(self._popen_git("log", *opts).stdout)))
+        opts = ([f"--max-count={str(max_count)}"] if max_count else []) + ["--format=%H", revision.full_name()]
+        return list(map(FullCommitHash.of, utils.get_non_empty_lines(self._popen_git("-c", "log.showSignature=0", "log", *opts).stdout)))
 
     # Since getting the full history of a branch can be an expensive operation for large repositories
     # (compared to all other underlying git operations), there are two optimizations in place:
@@ -630,7 +630,7 @@ class GitContext:
         all_branches: List[str] = local_branches + counterpart_branches
 
         # The trailing '--' is necessary to avoid ambiguity in case there is a file called just exactly like one of the branches.
-        entries = utils.get_non_empty_lines(self._popen_git("reflog", "show", "--no-show-signature", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])).stdout)
+        entries = utils.get_non_empty_lines(self._popen_git("-c", "log.showSignature=0", "reflog", "show", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])).stdout)
         self.__reflogs_cached = {}
         for entry in entries:
             values = entry.split("\t")
@@ -666,7 +666,7 @@ class GitContext:
                                                          [entry.split(":", 1) for entry in utils.get_non_empty_lines(
                                                              # The trailing '--' is necessary to avoid ambiguity in case there is a file
                                                              # called just exactly like the branch 'branch'.
-                                                             self._popen_git("reflog", "show", "--no-show-signature", "--format=%H:%gs", branch, "--").stdout)]
+                                                             self._popen_git("-c", "log.showSignature=0", "reflog", "show", "--format=%H:%gs", branch, "--").stdout)]
                                                          ))
             return self.__reflogs_cached[branch]
 
@@ -820,8 +820,9 @@ class GitContext:
         # shows all commits reachable from reachable_from_commit_hash but NOT from equivalent_to_commit_hash
         tree_hashes_for_reachable_from = utils.get_non_empty_lines(
             self._popen_git(
+                "-c",
+                "log.showSignature=0",
                 "log",
-                "--no-show-signature",
                 "--format=%T",  # full commit's tree hash
                 "^" + equivalent_to_commit_hash,
                 reachable_from_commit_hash
@@ -884,7 +885,7 @@ class GitContext:
     def __get_patch_ids_for_commits_between(
             self, earliest_exclusive: AnyRevision, latest_inclusive: AnyRevision, max_commits: int
     ) -> Dict[FullCommitHash, FullPatchId]:
-        patches = self._popen_git("log", "--no-show-signature", "--patch", f"^{earliest_exclusive}", latest_inclusive, f"-{max_commits}", "--").stdout
+        patches = self._popen_git("-c", "log.showSignature=0", "log", "--patch", f"^{earliest_exclusive}", latest_inclusive, f"-{max_commits}", "--").stdout
         patch_ids = self._popen_git("patch-id", input=patches).stdout
 
         patch_id_for_commit: Dict[FullCommitHash, FullPatchId] = {}
@@ -986,7 +987,7 @@ class GitContext:
             lambda x: GitLogEntry(hash=FullCommitHash(x.split(":", 2)[0]),
                                   short_hash=ShortCommitHash(x.split(":", 2)[1]),
                                   subject=x.split(":", 2)[2]),
-            utils.get_non_empty_lines(self._popen_git("log", "--no-show-signature", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--").stdout)
+            utils.get_non_empty_lines(self._popen_git("-c", "log.showSignature=0", "log", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--").stdout)
         ))))
 
     def get_relation_to_remote_counterpart(self, branch: LocalBranchShortName, remote_branch: RemoteBranchShortName) -> int:
@@ -1016,7 +1017,7 @@ class GitContext:
         # %gd - reflog selector (HEAD@{<unix-timestamp> <time-zone>} for `--date=raw`;
         #   `--date=unix` is not available on some older versions of git)
         # %gs - reflog subject
-        output = self._popen_git("reflog", "show", "--no-show-signature", "--format=%gd:%gs", "--date=raw").stdout
+        output = self._popen_git("-c", "log.showSignature=0", "reflog", "show", "--format=%gd:%gs", "--date=raw").stdout
         for entry in utils.get_non_empty_lines(output):
             pattern = "^HEAD@\\{([0-9]+) .+\\}:checkout: moving from (.+) to (.+)$"  # noqa: FS003
             match = re.search(pattern, entry)
@@ -1037,10 +1038,10 @@ class GitContext:
                 f"Retrieving {pattern} from commit is not supported. "
                 f"The currently supported patterns are: {', '.join(GitFormatPatterns._member_names_)}.")
 
-        return self._popen_git("log", "--no-show-signature", "-1", f"--format={pattern.value}", commit).stdout.strip()
+        return self._popen_git("-c", "log.showSignature=0", "log", "-1", f"--format={pattern.value}", commit).stdout.strip()
 
     def display_branch_history_from_fork_point(self, branch: LocalBranchFullName, fork_point: FullCommitHash) -> int:
-        return self._run_git("log", "--no-show-signature", f"^{fork_point}", branch, flush_caches=False)
+        return self._run_git("-c", "log.showSignature=0", "log", f"^{fork_point}", branch, flush_caches=False)
 
     def commit_tree_with_given_parent_and_message_and_env(
             self, parent_revision: AnyRevision, msg: str, env: Dict[str, str]) -> FullCommitHash:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -630,7 +630,14 @@ class GitContext:
         all_branches: List[str] = local_branches + counterpart_branches
 
         # The trailing '--' is necessary to avoid ambiguity in case there is a file called just exactly like one of the branches.
-        entries = utils.get_non_empty_lines(self._popen_git("-c", "log.showSignature=0", "reflog", "show", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])).stdout)
+        entries = utils.get_non_empty_lines(self._popen_git(
+            "-c",
+            "log.showSignature=0",
+            "reflog",
+            "show",
+            "--format=%gD\t%H\t%gs",
+            *(all_branches + ["--"])
+        ).stdout)
         self.__reflogs_cached = {}
         for entry in entries:
             values = entry.split("\t")
@@ -666,7 +673,15 @@ class GitContext:
                                                          [entry.split(":", 1) for entry in utils.get_non_empty_lines(
                                                              # The trailing '--' is necessary to avoid ambiguity in case there is a file
                                                              # called just exactly like the branch 'branch'.
-                                                             self._popen_git("-c", "log.showSignature=0", "reflog", "show", "--format=%H:%gs", branch, "--").stdout)]
+                                                             self._popen_git(
+                                                                 "-c",
+                                                                 "log.showSignature=0",
+                                                                 "reflog",
+                                                                 "show",
+                                                                 "--format=%H:%gs",
+                                                                 branch,
+                                                                 "--"
+                                                             ).stdout)]
                                                          ))
             return self.__reflogs_cached[branch]
 
@@ -885,7 +900,16 @@ class GitContext:
     def __get_patch_ids_for_commits_between(
             self, earliest_exclusive: AnyRevision, latest_inclusive: AnyRevision, max_commits: int
     ) -> Dict[FullCommitHash, FullPatchId]:
-        patches = self._popen_git("-c", "log.showSignature=0", "log", "--patch", f"^{earliest_exclusive}", latest_inclusive, f"-{max_commits}", "--").stdout
+        patches = self._popen_git(
+            "-c",
+            "log.showSignature=0",
+            "log",
+            "--patch",
+            f"^{earliest_exclusive}",
+            latest_inclusive,
+            f"-{max_commits}",
+            "--"
+        ).stdout
         patch_ids = self._popen_git("patch-id", input=patches).stdout
 
         patch_id_for_commit: Dict[FullCommitHash, FullPatchId] = {}
@@ -987,7 +1011,14 @@ class GitContext:
             lambda x: GitLogEntry(hash=FullCommitHash(x.split(":", 2)[0]),
                                   short_hash=ShortCommitHash(x.split(":", 2)[1]),
                                   subject=x.split(":", 2)[2]),
-            utils.get_non_empty_lines(self._popen_git("-c", "log.showSignature=0", "log", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--").stdout)
+            utils.get_non_empty_lines(self._popen_git(
+                "-c",
+                "log.showSignature=0",
+                "log", "--format=%H:%h:%s",
+                f"^{earliest_exclusive}",
+                latest_inclusive,
+                "--"
+            ).stdout)
         ))))
 
     def get_relation_to_remote_counterpart(self, branch: LocalBranchShortName, remote_branch: RemoteBranchShortName) -> int:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -640,12 +640,7 @@ class GitContext:
         all_branches: List[str] = local_branches + counterpart_branches
 
         # The trailing '--' is necessary to avoid ambiguity in case there is a file called just exactly like one of the branches.
-        entries = utils.get_non_empty_lines(self._popen_git(
-            "reflog",
-            "show",
-            "--format=%gD\t%H\t%gs",
-            *(all_branches + ["--"])
-        ).stdout)
+        entries = utils.get_non_empty_lines(self._popen_git("reflog", "show", "--format=%gD\t%H\t%gs", *(all_branches + ["--"])).stdout)
         self.__reflogs_cached = {}
         for entry in entries:
             values = entry.split("\t")
@@ -681,13 +676,7 @@ class GitContext:
                                                          [entry.split(":", 1) for entry in utils.get_non_empty_lines(
                                                              # The trailing '--' is necessary to avoid ambiguity in case there is a file
                                                              # called just exactly like the branch 'branch'.
-                                                             self._popen_git(
-                                                                 "reflog",
-                                                                 "show",
-                                                                 "--format=%H:%gs",
-                                                                 branch,
-                                                                 "--"
-                                                             ).stdout)]
+                                                             self._popen_git("reflog", "show", "--format=%H:%gs", branch, "--").stdout)]
                                                          ))
             return self.__reflogs_cached[branch]
 
@@ -904,14 +893,7 @@ class GitContext:
     def __get_patch_ids_for_commits_between(
             self, earliest_exclusive: AnyRevision, latest_inclusive: AnyRevision, max_commits: int
     ) -> Dict[FullCommitHash, FullPatchId]:
-        patches = self._popen_git(
-            "log",
-            "--patch",
-            f"^{earliest_exclusive}",
-            latest_inclusive,
-            f"-{max_commits}",
-            "--"
-        ).stdout
+        patches = self._popen_git("log", "--patch", f"^{earliest_exclusive}", latest_inclusive, f"-{max_commits}", "--").stdout
         patch_ids = self._popen_git("patch-id", input=patches).stdout
 
         patch_id_for_commit: Dict[FullCommitHash, FullPatchId] = {}
@@ -1013,12 +995,7 @@ class GitContext:
             lambda x: GitLogEntry(hash=FullCommitHash(x.split(":", 2)[0]),
                                   short_hash=ShortCommitHash(x.split(":", 2)[1]),
                                   subject=x.split(":", 2)[2]),
-            utils.get_non_empty_lines(self._popen_git(
-                "log", "--format=%H:%h:%s",
-                f"^{earliest_exclusive}",
-                latest_inclusive,
-                "--"
-            ).stdout)
+            utils.get_non_empty_lines(self._popen_git("log", "--format=%H:%h:%s", f"^{earliest_exclusive}", latest_inclusive, "--").stdout)
         ))))
 
     def get_relation_to_remote_counterpart(self, branch: LocalBranchShortName, remote_branch: RemoteBranchShortName) -> int:

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -1,6 +1,7 @@
 
-from git_machete.git_operations import (AnyRevision, FullCommitHash,
-                                        GitContext, LocalBranchShortName)
+from git_machete.git_operations import (AnyBranchName, AnyRevision,
+                                        FullCommitHash, GitContext,
+                                        LocalBranchShortName)
 
 from .base_test import BaseTest
 
@@ -169,3 +170,20 @@ class TestGitOperations(BaseTest):
         self.repo_sandbox.write_to_file(".git/config", '[foo]\n  bar = "hello\\nworld"')
         git = GitContext()
         assert git.get_config_attr_or_none("foo.bar") == "hello\nworld"
+
+    def test_get_reflog_when_log_showsignature_is_true(self) -> None:
+        (
+            self.repo_sandbox.new_branch("master")
+                .commit("master first commit")
+                .new_branch("feature")
+                .commit("feature commit")
+                .check_out("master")
+                .commit("extra commit")
+        )
+        self.repo_sandbox.set_git_config_key("log.showSignature", "true")
+
+        git = GitContext()
+
+        # If the bug reported in GitHub issue #1286 is not fixed, this method call
+        # should raise an UnexpectedMacheteException.
+        git.get_reflog(AnyBranchName.of("feature"))


### PR DESCRIPTION
If the `git` configuration setting `log.showSignature` is set to `true`, then some `git log` and `git reflog` invocations performed by `git-machete` return GPG signature output that causes `git-machete` to fail. The failures appear to occur because GPG signatures are assumed not to appear in the output of those commands.

This pull request resolves that failure mode by passing the `--no-show-signature` flag to all `git log` and `git reflog` queries. (Passing that flag to `git reflog` queries is necessary because `git reflog` is porcelain for `git log` plus some additional flags.)

Fixes #1286.