### PR TITLE
log: pass through certain `git log` options for `git machete log`

### DIFF
--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -1431,9 +1431,14 @@ class MacheteClient:
             fork_point=fork_point,
             format_with_stat=opt_stat)
 
-    def log(self, branch: LocalBranchShortName) -> None:
+    def log(self, branch: LocalBranchShortName, *, max_count: int | None = None, show_patch: bool = False) -> None:
         fork_point = self.fork_point(branch, use_overrides=True)
-        self.__git.display_branch_history_from_fork_point(branch.full_name(), fork_point)
+        extra_git_args = []
+        if max_count is not None:
+            extra_git_args.append(f"--max-count={max_count}")
+        if show_patch:
+            extra_git_args.append("--patch")
+        self.__git.display_branch_history_from_fork_point(branch.full_name(), fork_point, extra_git_args=extra_git_args)
 
     def down(self, branch: LocalBranchShortName, pick_mode: bool) -> List[LocalBranchShortName]:
         self.expect_in_managed_branches(branch)

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -4,8 +4,8 @@ import re
 import string
 import sys
 from pathlib import Path
-from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
-                    Set, Tuple)
+from typing import (Any, Dict, Iterable, Iterator, List, Match, NamedTuple,
+                    Optional, Set, Tuple)
 
 from . import utils
 from .constants import (MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION,
@@ -1048,8 +1048,9 @@ class GitContext:
 
         return self._popen_git("log", "-1", f"--format={pattern.value}", commit).stdout.strip()
 
-    def display_branch_history_from_fork_point(self, branch: LocalBranchFullName, fork_point: FullCommitHash) -> int:
-        return self._run_git("log", f"^{fork_point}", branch, flush_caches=False)
+    def display_branch_history_from_fork_point(
+            self, branch: LocalBranchFullName, fork_point: FullCommitHash, *, extra_git_args: Iterable[str]) -> int:
+        return self._run_git("log", f"^{fork_point}", branch, *extra_git_args, flush_caches=False)
 
     def commit_tree_with_given_parent_and_message_and_env(
             self, parent_revision: AnyRevision, msg: str, env: Dict[str, str]) -> FullCommitHash:

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -42,6 +42,8 @@ class CommandLineOptions:
         self.opt_unset_override: bool = False
         self.opt_with_urls: bool = False
         self.opt_yes: bool = False
+        self.opt_show_patch: bool = False
+        self.opt_max_count: int | None = None
 
     def validate(self) -> None:
         if self.opt_as_root and self.opt_onto:

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -43,7 +43,7 @@ class CommandLineOptions:
         self.opt_with_urls: bool = False
         self.opt_yes: bool = False
         self.opt_show_patch: bool = False
-        self.opt_max_count: int | None = None
+        self.opt_max_count: Optional[int] = None
 
     def validate(self) -> None:
         if self.opt_as_root and self.opt_onto:


### PR DESCRIPTION
Pass through the `-n` (`--max-count`) and `-p` (`--patch`) options for `git machete log`. These are useful to make use of.