### PR TITLE
Revert macOS job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2.1
 
 executors:
+  macos_executor:
+    macos:
+      # https://circleci.com/docs/using-macos/#supported-xcode-versions
+      xcode: 16.1.0
+    # https://circleci.com/docs/using-macos/#available-resource-classes
+    # https://circleci.com/pricing/#comparison-table
+    resource_class: macos.m1.medium.gen1
   ubuntu_executor:
     machine:
       # https://circleci.com/developer/images?imageType=machine
@@ -177,12 +184,24 @@ jobs:
           root: .
           paths: [ .coverage.* ]
 
-  # As of July 2024, there's no free macOS machine available on CircleCI :/
-  # See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718
-
   # Note the while we use Linux executor to test against specific Python&git version,
-  # on Windows we're just checking compatibility with the OS itself,
+  # on macOS and Windows we're just checking compatibility with the OS itself,
   # relying on whatever recent versions of Python and git are provided in the image.
+
+  "macos tests":
+    executor: macos_executor
+    steps:
+      - checkout
+      - run: brew install fish zsh
+      - run: pip install tox
+      # TODO (#1005): make zsh completion tests pass on macOS machine on CI
+      - run: tox -e test-completions -- -vv -k "not zsh"
+      - run: PYTHON_VERSION=3-macos  tox -e coverage -- -vv
+      - store_test_results:
+          path: test-results/
+      - persist_to_workspace:
+          root: .
+          paths: [ .coverage.* ]
 
   "windows tests":
     executor: windows_executor
@@ -286,6 +305,7 @@ test_jobs: &test_jobs
   - python 3_11 git 2_38_1
   - python 3_12 git 2_46_1
   - python 3_13 git 2_47_0
+  - macos tests
   - windows tests
 
 only_master: &only_master
@@ -306,6 +326,7 @@ workflows:
       - python 3_11 git 2_38_1
       - python 3_12 git 2_46_1
       - python 3_13 git 2_47_0
+      - macos tests
       - windows tests
       - coverage upload:
           requires:


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1345

## Chain of upstream PRs as of 2024-10-10

* PR #1345:
  `master` ← `develop`

  * **PR #1349 (THIS ONE)**:
    `develop` ← `chore/revert-macos-in-ci`

<!-- end git-machete generated -->


Undoes https://github.com/VirtusLab/git-machete/pull/1275