### PR TITLE
Allow disabling fetch for certain remotes in traverse

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - added: `git machete git{hub,lab} update-{pr,mr}-descriptions` subcommands
 - added: `git machete gith{hub,lab} create-{pr,mr} --update-related-descriptions` flags
+- added: `machete.traverse.fetch.<remote>` git config key to selectively exclude remotes from `git machete traverse --fetch` (contributed by @gjulianm)
 
 ## New in git-machete 3.30.0
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Nov 01, 2024" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Nov 05, 2024" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.31.0
 .sp
@@ -482,6 +482,12 @@ develop
 .EE
 .UNINDENT
 .UNINDENT
+.TP
+.B \fBmachete.traverse.fetch.<remote>\fP:
+Configures the behavior of \fBgit machete traverse\fP command for the given remote when \fB\-\-fetch\fP flag is used.
+If set to \fBfalse\fP, this remote will not be fetched before the traversal.
+The default value of this configuration is \fBtrue\fP\&.
+This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 .TP
 .B \fBmachete.traverse.push\fP:
 To change the behavior of \fBgit machete traverse\fP command so that it doesn\(aqt push branches by default,
@@ -2189,6 +2195,12 @@ whether a grey edge is displayed in \fBstatus\fP,
 .IP \(bu 2
 whether \fBtraverse\fP suggests to slide out the branch.
 .UNINDENT
+.TP
+.B \fBmachete.traverse.fetch.<remote>\fP:
+Configures the behavior of \fBgit machete traverse\fP command for the given remote when \fB\-\-fetch\fP flag is used.
+If set to \fBfalse\fP, this remote will not be fetched before the traversal.
+The default value of this configuration is \fBtrue\fP\&.
+This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 .TP
 .B \fBmachete.traverse.push\fP
 To change the behavior of \fBgit machete traverse\fP command so that it doesn\(aqt push branches by default,

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -52,7 +52,7 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
     .. include:: git-config-keys/traverse_push.rst
 
 ``machete.traverse.fetch.<remote>``:
-    Configures the behavior of ``git machete traverse`` command for the given remote when --fetch flag is used. If set to ``false``, this remote will not fetched before the traversal. The default value of this configuration is ``true``.
+    Configures the behavior of ``git machete traverse`` command for the given remote when ``--fetch`` flag is used. If set to ``false``, this remote will not be fetched before the traversal. The default value of this configuration is ``true``. This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 
 ``machete.worktree.useTopLevelMacheteFile``:
     The default value of this key is ``true``, which means that the path to branch layout file will be ``.git/machete``

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -51,6 +51,9 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 ``machete.traverse.push``:
     .. include:: git-config-keys/traverse_push.rst
 
+``machete.traverse.fetch.<remote>``:
+    Configures the behavior of ``git machete traverse`` command for the given remote when --fetch flag is used. If set to ``false``, this remote will not fetched before the traversal. The default value of this configuration is ``true``.
+
 ``machete.worktree.useTopLevelMacheteFile``:
     The default value of this key is ``true``, which means that the path to branch layout file will be ``.git/machete``
     for both regular directory and worktree.

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -48,11 +48,11 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 ``machete.status.extraSpaceBeforeBranchName``:
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst
 
+``machete.traverse.fetch.<remote>``:
+    .. include:: git-config-keys/traverse_fetch_remote.rst
+
 ``machete.traverse.push``:
     .. include:: git-config-keys/traverse_push.rst
-
-``machete.traverse.fetch.<remote>``:
-    Configures the behavior of ``git machete traverse`` command for the given remote when ``--fetch`` flag is used. If set to ``false``, this remote will not be fetched before the traversal. The default value of this configuration is ``true``. This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 
 ``machete.worktree.useTopLevelMacheteFile``:
     The default value of this key is ``true``, which means that the path to branch layout file will be ``.git/machete``

--- a/docs/source/cli/traverse.rst
+++ b/docs/source/cli/traverse.rst
@@ -147,5 +147,8 @@ when the current user is NOT the author of the PR/MR associated with that branch
 ``machete.squashMergeDetection``:
     .. include:: git-config-keys/squashMergeDetection.rst
 
+``machete.traverse.fetch.<remote>``:
+    .. include:: git-config-keys/traverse_fetch_remote.rst
+
 ``machete.traverse.push``
     .. include:: git-config-keys/traverse_push.rst

--- a/docs/source/git-config-keys/traverse_fetch_remote.rst
+++ b/docs/source/git-config-keys/traverse_fetch_remote.rst
@@ -1,0 +1,4 @@
+Configures the behavior of ``git machete traverse`` command for the given remote when ``--fetch`` flag is used.
+If set to ``false``, this remote will not be fetched before the traversal.
+The default value of this configuration is ``true``.
+This is useful for excluding remotes that are temporarily offline, or take a long time to respond.

--- a/git_machete/client.py
+++ b/git_machete/client.py
@@ -773,8 +773,9 @@ class MacheteClient:
 
         if opt_fetch:
             for rem in self.__git.get_remotes():
-                print(f"Fetching {bold(rem)}...")
-                self.__git.fetch_remote(rem)
+                if self.remote_enabled_for_traverse_fetch(rem):
+                    print(f"Fetching {bold(rem)}...")
+                    self.__git.fetch_remote(rem)
             if self.__git.get_remotes():
                 print("")
 
@@ -1868,6 +1869,9 @@ class MacheteClient:
                 else:
                     debug(f"upstream candidate {candidate} rejected ({reject_reason_message})")
         return None
+
+    def remote_enabled_for_traverse_fetch(self, remote: str) -> bool:
+        return self.__git.get_boolean_config_attr(git_config_keys.traverse_remote_fetch(remote), True)
 
     # Also includes config that is invalid (corresponding to a non-existent/GCed commit etc.).
     def has_any_fork_point_override_config(self, branch: LocalBranchShortName) -> bool:

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -346,15 +346,18 @@ long_docs: Dict[str, str] = {
               │
               └─ feature_branch2
 
+           `machete.traverse.fetch.<remote>`:
+              Configures the behavior of `git machete traverse` command for the given remote when `--fetch` flag is used.
+              If set to `false`, this remote will not be fetched before the traversal.
+              The default value of this configuration is `true`.
+              This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
+
            `machete.traverse.push`:
  
               To change the behavior of `git machete traverse` command so that it doesn't push branches by default,
               you need to set config key `git config machete.traverse.push false`.
 
               Configuration key value can be overridden by the presence of the `--push` or `--push-untracked` flags.
-
-           `machete.traverse.fetch.<remote>`:
-              Configures the behavior of `git machete traverse` command for the given remote when --fetch flag is used. If set to `false`, this remote will not fetched before the traversal. The default value of this configuration is `true`.
 
            `machete.worktree.useTopLevelMacheteFile`:
  
@@ -1534,6 +1537,12 @@ long_docs: Dict[str, str] = {
                  * whether a grey edge is displayed in `status`,
 
                  * whether `traverse` suggests to slide out the branch.
+
+           `machete.traverse.fetch.<remote>`:
+              Configures the behavior of `git machete traverse` command for the given remote when `--fetch` flag is used.
+              If set to `false`, this remote will not be fetched before the traversal.
+              The default value of this configuration is `true`.
+              This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 
            `machete.traverse.push`
  

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -353,6 +353,9 @@ long_docs: Dict[str, str] = {
 
               Configuration key value can be overridden by the presence of the `--push` or `--push-untracked` flags.
 
+           `machete.traverse.fetch.<remote>`:
+              Configures the behavior of `git machete traverse` command for the given remote when --fetch flag is used. If set to `false`, this remote will not fetched before the traversal. The default value of this configuration is `true`.
+
            `machete.worktree.useTopLevelMacheteFile`:
  
               The default value of this key is `true`, which means that the path to branch layout file will be `.git/machete`

--- a/git_machete/git_config_keys.py
+++ b/git_machete/git_config_keys.py
@@ -11,5 +11,6 @@ def override_fork_point_to(branch: str) -> str:
 def override_fork_point_while_descendant_of(branch: str) -> str:
     return f'machete.overrideForkPoint.{branch}.whileDescendantOf'
 
+
 def traverse_remote_fetch(remote: str) -> str:
     return f'machete.traverse.fetch.{remote}'

--- a/git_machete/git_config_keys.py
+++ b/git_machete/git_config_keys.py
@@ -10,3 +10,6 @@ def override_fork_point_to(branch: str) -> str:
 
 def override_fork_point_while_descendant_of(branch: str) -> str:
     return f'machete.overrideForkPoint.{branch}.whileDescendantOf'
+
+def traverse_remote_fetch(remote: str) -> str:
+    return f'machete.traverse.fetch.{remote}'

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1167,8 +1167,8 @@ class TestTraverse(BaseTest):
         (
             self.repo_sandbox
             .remove_remote("origin")
-            .add_remote("origin_1", origin_1_remote_path)
-            .add_remote("origin_2", origin_2_remote_path)
+            .add_remote("origin-1", origin_1_remote_path)
+            .add_remote("origin-2", origin_2_remote_path)
         )
 
         self.repo_sandbox.new_branch("master").commit()
@@ -1176,11 +1176,14 @@ class TestTraverse(BaseTest):
 
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("xd"))
         assert_success(
-            ["traverse"],
+            ["traverse", "--fetch"],
             """
+            Fetching origin-1...
+            Fetching origin-2...
+
             Branch master is untracked and there's no origin remote.
-            [1] origin_1
-            [2] origin_2
+            [1] origin-1
+            [2] origin-2
             Select number 1..2 to specify the destination remote repository, or 'n' to skip this branch, or 'q' to quit the traverse:
 
               master * (untracked)
@@ -1190,18 +1193,21 @@ class TestTraverse(BaseTest):
         )
 
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("1", "o", "2", "yq"))
+        self.repo_sandbox.set_git_config_key("machete.traverse.fetch.origin-2", "false")
         assert_success(
-            ["traverse"],
+            ["traverse", "--fetch"],
             """
+            Fetching origin-1...
+
             Branch master is untracked and there's no origin remote.
-            [1] origin_1
-            [2] origin_2
+            [1] origin-1
+            [2] origin-2
             Select number 1..2 to specify the destination remote repository, or 'n' to skip this branch, or 'q' to quit the traverse:
-            Push untracked branch master to origin_1? (y, N, q, yq, o[ther-remote])
-            [1] origin_1
-            [2] origin_2
+            Push untracked branch master to origin-1? (y, N, q, yq, o[ther-remote])
+            [1] origin-1
+            [2] origin-2
             Select number 1..2 to specify the destination remote repository, or 'n' to skip this branch, or 'q' to quit the traverse:
-            Push untracked branch master to origin_2? (y, N, q, yq, o[ther-remote])
+            Push untracked branch master to origin-2? (y, N, q, yq, o[ther-remote])
             """
         )
 


### PR DESCRIPTION
This PR adds a new configuration option, `machete.traverse.fetch.<remote>`, that allows disabling the fetch on certain remotes when running `git machete traverse --fetch` (or `git machete traverse -W`, which includes `--fetch`). 

The motivation: we might have remotes that are temporarily offline, or take a long time to respond, but are not the main remote we use to synchronize. This config allows continued usage of `git machete traverse -W` for the remotes that are working.