### PR TITLE
Close GitHub milestone after creating a release in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           # language=sh
           command: |
             set -x
+
             python --version
             pip3 install tox
 
@@ -280,12 +281,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: 'Create GitHub release'
+          name: 'Create GitHub release and close milestone'
           # language=sh
           command: |
             sudo apt-get update
-            sudo apt-get install hub
-            bash ci/github-releases/ci-deploy.sh
+            sudo apt-get install gh
+            bash ci/github/create-release.sh
+            bash ci/github/close-milestone.sh
 
 
 # Note that these top-level keys are NOT consumed by CircleCI,

--- a/ci/github/close-milestone.sh
+++ b/ci/github/close-milestone.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u -x
+
+milestone_title=v$(cut -d\' -f2 git_machete/__init__.py)
+
+milestones_json_array=$(gh api repos/VirtusLab/git-machete/milestones)
+milestone=$(echo "$milestones_json_array" | jq -c --arg TITLE "$milestone_title" '.[] | select(.title == $TITLE)')
+
+number=$(echo "$milestone" | jq '.number')
+# open issues and PRs are counted together in the same field
+open_issue_count=$(echo "$milestone" | jq '.open_issues')
+
+if [[ $open_issue_count = 0 ]]; then
+  gh api --method PATCH "repos/VirtusLab/git-machete/milestones/$number" -f state=closed
+fi

--- a/ci/github/create-release.sh
+++ b/ci/github/create-release.sh
@@ -5,5 +5,6 @@ set -e -o pipefail -u -x
 tag=v$(cut -d\' -f2 git_machete/__init__.py)
 # Note that this will also create a git tag on the remote
 # (since apparently all non-draft releases on GitHub must have a corresponding git tag).
-hub release create "$tag" \
-  --message="$tag"$'\n\n'"$(sed '5,/^$/!d; /^$/d' RELEASE_NOTES.md)" \
+gh release create "$tag" \
+  --title "$tag" \
+  --notes "$(sed '5,/^$/!d; /^$/d' RELEASE_NOTES.md)"


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1454

## Chain of upstream PRs as of 2025-07-03

* PR #1454:
  `develop` ← `fix/bisect-recognize`

  * **PR #1455 (THIS ONE)**:
    `fix/bisect-recognize` ← `chore/close-github-milestone`

<!-- end git-machete generated -->
