### PR TITLE
No longer slide out branches marked as `slide-out=no` in `git machete slide-out --removed-from-remote`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - fixed: incorrect `Could not determine base branch for PR` error messages when creating PRs from `git machete traverse -H`
 - fixed: `git bisect` is recognized as a separate repository state by `git machete status` and side-effecting operations
+- fixed: branches marked as `slide-out=no` are no longer slid out by `git machete slide-out --removed-from-remote`
 
 ## New in git-machete 3.36.0
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Jun 27, 2025" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Jul 03, 2025" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.36.1
 .sp

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -117,8 +117,12 @@ class SlideOutMacheteClient(MacheteClient):
         slid_out_branches: List[LocalBranchShortName] = []
         for branch in self.managed_branches.copy():
             if self._git.is_removed_from_remote(branch) and not self.down_branches_for(branch):
-                print(fmt(f"Sliding out <b>{branch}</b>"))
-                slid_out_branches.append(branch)
+                anno = self.annotations.get(branch)
+                if anno and not anno.qualifiers.slide_out:
+                    print(fmt(f"Skipping <b>{branch}</b> as it's marked as `slide-out=no`"))
+                else:
+                    print(fmt(f"Sliding out <b>{branch}</b>"))
+                    slid_out_branches.append(branch)
 
         self._remove_branches_from_layout(slid_out_branches)
         if opt_delete:


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1456

## Chain of upstream PRs as of 2025-07-03

* PR #1454:
  `develop` ← `fix/bisect-recognize`

  * PR #1455:
    `fix/bisect-recognize` ← `chore/close-github-milestone`

    * PR #1456:
      `chore/close-github-milestone` ← `docs/more-spacing`

      * **PR #1457 (THIS ONE)**:
        `docs/more-spacing` ← `fix/slide-out-no-remove-from-remote`

<!-- end git-machete generated -->
