### PR TITLE
Replace tabs with spaces in user-facing messages

### DIFF
--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -56,9 +56,9 @@ class SquashMacheteClient(MacheteClient):
         print(f"Squashed {len(commits)} commits:")
         print()
         for commit in commits:
-            print(f"\t{commit.short_hash} {commit.subject}")
+            print(f"    {commit.short_hash} {commit.subject}")
 
         print()
         print("To restore the original pre-squash commit, run:")
         print()
-        print(fmt(f"\t`git reset {commits[-1].hash}`"))
+        print(fmt(f"    `git reset {commits[-1].hash}`"))

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -440,10 +440,10 @@ GITHUB_CLIENT_SPEC = CodeHostingSpec(
     pr_short_name_article='a',
     repository_name='repository',
     token_providers_message=(
-        f'\n\t1. `{GITHUB_TOKEN_ENV_VAR}` environment variable\n'
-        '\t2. Content of the `~/.github-token` file\n'
-        '\t3. Current auth token from the `gh` GitHub CLI\n'
-        '\t4. Current auth token from the `hub` GitHub CLI\n'
+        f'\n    1. `{GITHUB_TOKEN_ENV_VAR}` environment variable\n'
+        '    2. Content of the `~/.github-token` file\n'
+        '    3. Current auth token from the `gh` GitHub CLI\n'
+        '    4. Current auth token from the `hub` GitHub CLI\n'
     ),
     git_config_keys=CodeHostingGitConfigKeys(
         domain='machete.github.domain',

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -350,9 +350,9 @@ GITLAB_CLIENT_SPEC = CodeHostingSpec(
     pr_short_name_article='an',
     repository_name='project',
     token_providers_message=(
-        f'\n\t1. `{GITLAB_TOKEN_ENV_VAR}` environment variable\n'
-        '\t2. Content of the `~/.gitlab-token` file\n'
-        '\t3. Current auth token from the `glab` GitLab CLI\n'
+        f'\n    1. `{GITLAB_TOKEN_ENV_VAR}` environment variable\n'
+        '    2. Content of the `~/.gitlab-token` file\n'
+        '    3. Current auth token from the `glab` GitLab CLI\n'
     ),
     git_config_keys=CodeHostingGitConfigKeys(
         domain='machete.gitlab.domain',

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -79,10 +79,10 @@ class TestClean(BaseTest):
             ["clean", "--checkout-my-github-prs"],
             """
             Warn: Could not determine current user name, please check that the GitHub API token provided by one of the:
-            \t1. GITHUB_TOKEN environment variable
-            \t2. Content of the ~/.github-token file
-            \t3. Current auth token from the gh GitHub CLI
-            \t4. Current auth token from the hub GitHub CLI
+                1. GITHUB_TOKEN environment variable
+                2. Content of the ~/.github-token file
+                3. Current auth token from the gh GitHub CLI
+                4. Current auth token from the hub GitHub CLI
             is valid.
             Checking for unmanaged branches...
             No branches to delete

--- a/tests/test_github_checkout_prs.py
+++ b/tests/test_github_checkout_prs.py
@@ -512,10 +512,10 @@ class TestGitHubCheckoutPRs(BaseTest):
             ["github", "checkout-prs", "--mine"],
             """
             Could not determine current user name, please check that the GitHub API token provided by one of the:
-            \t1. GITHUB_TOKEN environment variable
-            \t2. Content of the ~/.github-token file
-            \t3. Current auth token from the gh GitHub CLI
-            \t4. Current auth token from the hub GitHub CLI
+                1. GITHUB_TOKEN environment variable
+                2. Content of the ~/.github-token file
+                3. Current auth token from the gh GitHub CLI
+                4. Current auth token from the hub GitHub CLI
             is valid."""
         )
 

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -269,10 +269,10 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ["github", "update-pr-descriptions", "--mine"],
             """
             Could not determine current user name, please check that the GitHub API token provided by one of the:
-            \t1. GITHUB_TOKEN environment variable
-            \t2. Content of the ~/.github-token file
-            \t3. Current auth token from the gh GitHub CLI
-            \t4. Current auth token from the hub GitHub CLI
+                1. GITHUB_TOKEN environment variable
+                2. Content of the ~/.github-token file
+                3. Current auth token from the gh GitHub CLI
+                4. Current auth token from the hub GitHub CLI
             is valid."""
         )
 

--- a/tests/test_gitlab_checkout_mrs.py
+++ b/tests/test_gitlab_checkout_mrs.py
@@ -513,9 +513,9 @@ class TestGitLabCheckoutMRs(BaseTest):
             ["gitlab", "checkout-mrs", "--mine"],
             """
             Could not determine current user name, please check that the GitLab API token provided by one of the:
-            \t1. GITLAB_TOKEN environment variable
-            \t2. Content of the ~/.gitlab-token file
-            \t3. Current auth token from the glab GitLab CLI
+                1. GITLAB_TOKEN environment variable
+                2. Content of the ~/.gitlab-token file
+                3. Current auth token from the glab GitLab CLI
             is valid."""
         )
 

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -268,9 +268,9 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ["gitlab", "update-mr-descriptions", "--mine"],
             """
             Could not determine current user name, please check that the GitLab API token provided by one of the:
-            \t1. GITLAB_TOKEN environment variable
-            \t2. Content of the ~/.gitlab-token file
-            \t3. Current auth token from the glab GitLab CLI
+                1. GITLAB_TOKEN environment variable
+                2. Content of the ~/.gitlab-token file
+                3. Current auth token from the glab GitLab CLI
             is valid."""
         )
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1475

## Chain of upstream PRs as of 2025-07-23

* PR #1472:
  `develop` ← `docs/rebase-opts`

  * PR #1473:
    `docs/rebase-opts` ← `refactor/cli-parsers`

    * PR #1474:
      `refactor/cli-parsers` ← `fix/chdir-empty-after-test`

      * PR #1475:
        `fix/chdir-empty-after-test` ← `docs/drop-3rd-person`

        * **PR #1476 (THIS ONE)**:
          `docs/drop-3rd-person` ← `fix/spaces-not-tabs-in-msgs`

<!-- end git-machete generated -->
