### PR TITLE
fix(gitlab): update glab CLI token regex to support latest PAT format and auth status output format

### DIFF
--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -89,7 +89,9 @@ class GitLabToken(NamedTuple):
         # As of glab version 1.36.0, this output goes to stderr.
         # As of glab version 1.66.0, the token line was changed from
         # "Token: glpat..." to "Token found: glpat..."
-        match = re.search(r"Token(?: found)?: ([\w-]+)", glab_token_stderr)
+
+        # Note: Newer GitLab personal access tokens can contain "."s
+        match = re.search(r"Token(?: found)?: ([.\w-]+)", glab_token_stderr)
         if match:
             return cls(value=match.group(1), provider=f'auth token for {domain} from `glab` GitLab CLI')
         return None

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -83,11 +83,13 @@ class GitLabToken(NamedTuple):
         # {domain}:
         #   ✓ Logged in to {domain} as {username} ({config_path})
         #   ✓ Git operations for {domain} configured to use {protocol} protocol.
-        #   ✓ Token: <token>
+        #   ✓ Token found: <token>
         #
         # with non-zero exit code on failure.
         # As of glab version 1.36.0, this output goes to stderr.
-        match = re.search(r"Token: ([\w-]+)", glab_token_stderr)
+        # As of glab version 1.66.0, the token line was changed from
+        # "Token: glpat..." to "Token found: glpat..."
+        match = re.search(r"Token(?: found)?: ([\w-]+)", glab_token_stderr)
         if match:
             return cls(value=match.group(1), provider=f'auth token for {domain} from `glab` GitLab CLI')
         return None

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -295,7 +295,6 @@ class TestGitLab(BaseTest):
         assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
         assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0'
 
-
         fixed_popen_cmd_result = (0, "", """gitlab.com
                                           ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
                                           ✓ Git operations for gitlab.com configured to use https protocol.
@@ -308,6 +307,19 @@ class TestGitLab(BaseTest):
         assert gitlab_token is not None
         assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
         assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0'
+
+        fixed_popen_cmd_result = (0, "", """gitlab.com
+                                          ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+                                          ✓ Git operations for gitlab.com configured to use https protocol.
+                                          ✓ API calls for gitlab.com are made over https protocol.
+                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
+                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
+                                          ✓ Token found: glpat-mytoken_for_gitlab_com.containing.dots""")
+        self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
+        gitlab_token = GitLabToken.for_domain(domain=domain)
+        assert gitlab_token is not None
+        assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
+        assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com.containing.dots'
 
     def test_gitlab_invalid_flag_combinations(self) -> None:
         create_repo()

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -288,12 +288,26 @@ class TestGitLab(BaseTest):
                                           ✓ API calls for gitlab.com are made over https protocol
                                           ✓ REST API Endpoint: https://gitlab.com/api/v4/
                                           ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
-                                          ✓ Token: glpat-mytoken_for_gitlab_com_from_glab_cli""")
+                                          ✓ Token: glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0""")
         self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
         gitlab_token = GitLabToken.for_domain(domain=domain)
         assert gitlab_token is not None
         assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
-        assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli'
+        assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0'
+
+
+        fixed_popen_cmd_result = (0, "", """gitlab.com
+                                          ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+                                          ✓ Git operations for gitlab.com configured to use https protocol.
+                                          ✓ API calls for gitlab.com are made over https protocol.
+                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
+                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
+                                          ✓ Token found: glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0""")
+        self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
+        gitlab_token = GitLabToken.for_domain(domain=domain)
+        assert gitlab_token is not None
+        assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
+        assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0'
 
     def test_gitlab_invalid_flag_combinations(self) -> None:
         create_repo()


### PR DESCRIPTION
1. PAT format for new tokens contains 3 "." separated segments e.g. "glpat-somechars.[\d\d].somechars", which doesn't work with the current token regex
2. `glab` auth status output has changed the line prefix for the token as of v1.66, which also doesn't work with the current token regex